### PR TITLE
Add deploy to balena action

### DIFF
--- a/.github/workflows/deploy-to-balena.yml
+++ b/.github/workflows/deploy-to-balena.yml
@@ -1,0 +1,35 @@
+name: "Deploy to Balena"
+
+on:
+  pull_request:
+    types: [opened, synchronize, closed]
+    branches:
+      - main
+      - master
+    paths-ignore:
+      - 'docs/**'
+
+env:
+  BALENA_APP: ketil/balena-ads-b
+
+jobs:
+  build:
+    name: "Deploy-to-Balena"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v3
+
+      - name: Update balena.yml
+        uses: balena-io-experimental/balena.yml-action@main
+        with:
+          # Synchronise the GitHub README with the Balena Hub README
+          sync_readme: true
+          # If pushing a tag to deploy, use the same tag as the version number to display on Balena Hub
+          sync_tag: false
+
+      - name: Deploy to Balena
+        uses: balena-io/deploy-to-balena-action@master
+        with:
+          balena_token: ${{ secrets.BALENA_API_KEY }}
+          fleet: ${{ env.BALENA_APP }}


### PR DESCRIPTION
Hi,

I have added here a GitHub workflow action which auto deploys to the Balena Hub (https://github.com/balena-io/deploy-to-balena-action). It means there will be no need to manually push the code to the Hub, but the main reason I am hoping to add it here is there is another action in there that synchronises the Balena Hub readme with the one stored here in the GitHub repository. I didn't know about your app until someone pointed it out to me, and I think updating the Docs on the Hub will make it more searchable. 

For the action to work you would need to [generate an API key](https://www.balena.io/docs/learn/manage/account/#api-keys) for your Hub account and add it to this repo as a [GitHub secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) called `BALENA_API_KEY`.

It will then do a test build on each pull request, and when the PR merges it will deploy it to the live environment. 

Thanks for making this project :) 



