### PR TITLE
fix: stop radarbox from spamming the logs

### DIFF
--- a/radarbox/Dockerfile.template
+++ b/radarbox/Dockerfile.template
@@ -55,4 +55,6 @@ RUN	mkdir -p /var/radarbox/thermal/thermal_zone0/ && \
 	chmod +x /showkey.sh && \
 	rm -rf /tmp/*
 
+mkdir -p /run/shm//
+
 ENTRYPOINT ["/start.sh"]


### PR DESCRIPTION
radarbox is spamming the logs with messages like:
```
failed to create /run/shm//rbfeeder_history_116.json.LwBBce (while updating /run/shm//rbfeeder_history_116.json): No such file or directory (124 more error messages suppressed)
```

This stops the log spamming by creating the folder it is expecting.