### PR TITLE
fix: fix mlat version to correct repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,12 @@ Software packages downloaded, installed, and configured by the balena-ads-b scri
 - [Part 12 – Exploring flight traffic locally on your device](#part-12--exploring-flight-traffic-locally-on-your-device)
 - [Part 13 – Advanced configuration](#part-13--advanced-configuration)
   * [Disabling specific services](#disabling-specific-services)
+  * [Using different radio device types](#using-different-radio-device-types)
   * [Adaptive gain configuration](#adaptive-gain-configuration)
   * [Setting dump1090 antenna gain](#setting-dump1090-antenna-gain)
+  * [Device reboot on service exit](#device-reboot-on-service-exit)
+  * [Automatic balenaOS host updates](#automatic-balenaos-host-updates)
+  * [Custom MLAT client](#custom-mlat-client)
  - [Part 14 – Updating to the latest version](#part-14--updating-to-the-latest-version)
 
 # Part 1 – Build the receiver
@@ -461,10 +465,18 @@ dump978 and dump1090 can restart the device if it hits an error. You can enable 
 
 ## Automatic balenaOS host updates
 
-Automatically keep your balenaOS host release up-to-date. To enable this service, create a *Device Variables* named `ENABLED_SERVICES` with the value of `autohupr`.
+Automatically keep your balenaOS host release up-to-date. To enable this service, create a *Device Variables* named `ENABLED_SERVICES` with the value of `autohupr`. You may also want to set the following *Device Variables*:
 
 - `HUP_CHECK_INTERVAL`: Interval between checking for available updates. Default is 1d.
 - `HUP_TARGET_VERSION`: The OS version you want balenaHUP to automatically update your device to. This is a required variable to be specified, otherwise, an update won't be performed by default. Set the variable to 'latest'/'recommended' for your device to always update to the latest OS version or set it to a specific version (e.g '2.107.10').
+
+## Custom MLAT client
+
+In the [docker compose file]([https://github.com/ketilmo/balena-ads-b/blob/shawaj/mlat-version/docker-compose.yml](https://github.com/ketilmo/balena-ads-b/blob/master/docker-compose.yml#L258-L271)) you will notice at the bottom there is a section labelled `Optional: Uncomment to enable custom mlat server.` This allows you to share MLAT data with an MLAT server of your choosing, unrelated to any of the above services.
+
+In order to enable this, you will need to fork the repo and edit the docker-compose.yml file to remove the `#` at the beginning of each line starting with the one that says `mlat-client`. Once done you should save the file, and then you can deploy it to your fleet using the manual method described above in [Part 2 – Setup balena and configure the device](#part-2--setup-balena-and-configure-the-device).
+
+You will also need to add *Device Variables* named `MLAT_CLIENT_USER` with a value of your desired username or UUID and another one named `MLAT_SERVER` with a value or your desired MLAT server address and port. For example you might have an `MLAT_CLIENT_USER` of `0327791e-3777-40a5-addc-aa13408d3b07` and an `MLAT_SERVER` of `feed.mymlatserver.com:31090`.
 
 # Part 14 – Updating to the latest version
 Updating to the latest version is trivial. If you installed balena-ads-b using the blue Deploy with balena-button, you can click it again and overwrite your current application. Choose the "Deploy to existing fleet" option, then select the fleet you want to update. All settings will be preserved. For convenience, the button is right here:

--- a/adsb-exchange/Dockerfile.template
+++ b/adsb-exchange/Dockerfile.template
@@ -23,8 +23,8 @@ FROM base AS buildstep
 
 # renovate: datasource=github-tags depName=wiedehopf/readsb versioning=loose
 ARG READSB_VERSION=v3.14.1645
-# renovate: datasource=github-tags depName=adsb-related-code/mlat-client versioning=loose
-ARG MLAT_VERSION=v0.4.2
+# renovate: datasource=git-refs depName=wiedehopf/mlat-client versioning=loose
+ARG MLAT_VERSION=3f0bfb8c5202afb3a9a827ec9d2e82cac4f12819
 ARG TEMP_INSTALL="git build-essential debhelper libncurses5-dev zlib1g-dev python3-dev libzstd-dev pkg-config"
 
 WORKDIR /tmp
@@ -32,8 +32,9 @@ WORKDIR /tmp
 RUN apt update && \
 	apt install -y $TEMP_INSTALL
 
-RUN git clone --depth 1 --branch $MLAT_VERSION https://github.com/adsb-related-code/mlat-client && \
+RUN git clone --single-branch https://github.com/wiedehopf/mlat-client && \
 	cd mlat-client && \
+        git checkout ${MLAT_VERSION} && \
     python3 -m venv /usr/local/share/adsbexchange/venv/ && \	
     /usr/local/share/adsbexchange/venv/bin/python3 setup.py build && \	
     /usr/local/share/adsbexchange/venv/bin/python3 setup.py install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -267,6 +267,7 @@ services:
 #      - LON=
 #      - ALT=
 #      - MLAT_CLIENT_USER=
+#      - MLAT_SERVER=
 #    labels:
 #      io.balena.features.supervisor-api: '1'
 

--- a/mlat-client/Dockerfile.template
+++ b/mlat-client/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_ARCH%%-debian:bullseye AS base
+FROM balenalib/%%BALENA_ARCH%%-debian:bookworm AS base
 LABEL maintainer="https://github.com/ketilmo"
 
 ENV LAT=
@@ -18,8 +18,8 @@ RUN apt update && \
 
 FROM base AS buildstep
 
-# renovate: datasource=github-tags depName=adsb-related-code/mlat-client versioning=loose
-ARG MLAT_VERSION=v0.4.2
+# renovate: datasource=git-refs depName=wiedehopf/mlat-client versioning=loose
+ARG MLAT_VERSION=3f0bfb8c5202afb3a9a827ec9d2e82cac4f12819
 ARG TEMP_INSTALL="build-essential debhelper python3-dev git" 
 
 RUN apt update && \
@@ -27,8 +27,9 @@ RUN apt update && \
 
 WORKDIR /tmp
 
-RUN git clone --depth 1 --branch $MLAT_VERSION https://github.com/wiedehopf/mlat-client/ && \
+RUN git clone --single-branch https://github.com/wiedehopf/mlat-client && \
 	cd mlat-client && \
+        git checkout ${MLAT_VERSION} && \
     python3 -m venv /usr/local/share/mlat-client/venv/ && \	
     /usr/local/share/mlat-client/venv/bin/python3 setup.py build && \	
     /usr/local/share/mlat-client/venv/bin/python3 setup.py install

--- a/renovate.json
+++ b/renovate.json
@@ -43,6 +43,15 @@
       "matchStrings": ["OPENSKY_VERSION=(?<currentValue>.*?)\\n"],
       "depNameTemplate": "opensky",
       "datasourceTemplate": "custom.opensky"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)Dockerfile\\.[^/]*$"],
+      "matchStrings": ["MLAT_VERSION=(?<currentDigest>.*?)\\n"],
+      "currentValueTemplate": "master",
+      "depNameTemplate": "wiedehopf/mlat-client",
+      "packageNameTemplate": "https://github.com/wiedehopf/mlat-client",
+      "datasourceTemplate": "git-refs"
     }
   ],
   "customDatasources": {


### PR DESCRIPTION
- correctly use wiedehopf version as per https://github.com/ketilmo/balena-ads-b/commit/e4aec8418b4c4f36e7288b3f4b351b876b7bfcd5
- update to latest version of mlat-client
- update to bookworm for mlat-client image
- add readme item for custom mlat-client
- update renovate.json for new repo