### PR TITLE
fix: invalid JSON in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -77,7 +77,7 @@
       "defaultRegistryUrlTemplate": "https://install.wingbits.com/linux-arm64.json",
       "transformTemplates": [
         "{\"releases\":[{\"version\": $.Version}]}"
-      ],
+      ]
     }
   },
   "packageRules": [


### PR DESCRIPTION
fix up the renovate.json

To fix error as below:
```
Repository problems
These problems occurred while renovating this repository.

File contents are invalid JSON but parse using JSON5. Support for this will be removed in a future release so please change to a support .json5 file name or ensure correct JSON syntax.
```