### PR TITLE
wingbits: remove redundant mkdir

### DIFF
--- a/wingbits/Dockerfile.template
+++ b/wingbits/Dockerfile.template
@@ -51,7 +51,6 @@ RUN chmod +x /tmp/wingbits_installer.sh && \
 	./wingbits_installer.sh && \
 	chmod +x /start.sh && \
 	mkdir -p /run/wingbits-feed && \
-	mkdir -p /etc/wingbits && \
 	echo "$WINGBITS_CONFIG_VERSION" > /etc/wingbits/version && \
         echo "$WINGBITS_COMMIT_ID" > /etc/wingbits/json-version && \
 	rm -rf /tmp/*


### PR DESCRIPTION
mkdir already in installer script. not needed here too