### PR TITLE
AirNav Radar: Removed armhf emulation for arm64

### DIFF
--- a/airnav-radar/airnavradar_installer.sh
+++ b/airnav-radar/airnavradar_installer.sh
@@ -18,11 +18,6 @@ if [ "$arch" = "i386" ] || [ "$arch" = "amd64" ]; then
 	dpkg --add-architecture armhf
 		apt update  && apt install -y --no-install-recommends \
 	    rbfeeder:armhf qemu-user qemu-user-static binfmt-support libc6-armhf-cross
-# This elif is hopefully a temporary workaround, as the newest AirNav Radar library is not currently available for arm64.	    
-elif [ "$arch" = "arm64" ]; then 
-	dpkg --add-architecture armhf
-		apt update  && apt install -y --no-install-recommends \
-	    rbfeeder:armhf
 else 
     apt update && apt install -y --no-install-recommends \
 	    rbfeeder


### PR DESCRIPTION
AirNav has recently added native support for arm64, making the armhf emulation we have been doing up until now redundant on that platform. I have verified that this change works on a Raspberry Pi5, running the latest version of the balenaOS.

Resolves #305.