### PR TITLE
readme: add note about raspi 4 recommended for airspy

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,17 +480,19 @@ If you are using a Mode-S Beast, Airspy, bladeRF, HackRF, LimeSDR or SoapySDR th
 
 In order to configure the particular device type you are using, you need to create a *Device Variable* named `RADIO_DEVICE_TYPE`. The possible values are below:
 
-- rtlsdr (this is the default and you do not need to configure this variable if you are using an RTL-SDR)
-- modesbeast
-- airspy
-- bladerf
-- hackrf
-- limesdr
-- soapysdr
+- `rtlsdr` (this is the default and you do not need to configure this variable if you are using an RTL-SDR)
+- `modesbeast`
+- `airspy`
+- `bladerf`
+- `hackrf`
+- `limesdr`
+- `soapy`
 
 For example if you have a Mode-S Beast, you set the `RADIO_DEVICE_TYPE` variable to `modesbeast`. Remember to save the device variable settings after you have updated them. Your device should restart automatically once you configure this and the radio should now work.
 
 ### Airspy Setup
+
+**Please Note:** If you are using an Airspy radio module, it is recommended to use a Raspberry Pi 4 or a device that is as (or more) powerful. Whilst Airspy will work with less powerful hardware, the performance will be degraded and you may need to tweak some of the default settings.
 
 If you use Airspy and need to power active antennas or preamplifiers, you can enable the bias tee by setting a *Device Variable* named `AIRSPY_ADSB_BIASTEE` to `true`.
 
@@ -499,7 +501,7 @@ If you have multiple Airspy modules connected to the same device, you can differ
 **Important:** If the serial number is in hexadecimal format, prefix it with `0x`, e.g., `0x00B512CD22524212`.
 
 There are some other *Device Variables* you can use as well:
-- `AIRSPY_ADSB_STATS` defaults to false, as it causes additional writes to the SD card. However, if you are using graphs1090 and would like to see additional Airspy specific graph output you can create a *Device Variable* and set its value to `true`.
+- `AIRSPY_ADSB_STATS` defaults to false, as it causes additional writes to the SD card. However, if you are using [graphs1090](#:~:text=Graphs1090%20Stats%20Graphs) and would like to see additional Airspy specific graph output you can create a *Device Variable* and set its value to `true`.
 - `AIRSPY_ADSB_GAIN` has a default setting of `auto`. The auto setting works very well so it is not recommended to change it. However, if you have a specific reason to you can use a setting from 0 to 21.
 - `AIRSPY_ADSB_SAMPLE_RATE` has a default setting of 12. On the Airspy R2 you can also use 20 or 24 however these can be unstable so are not recommended unless you have a specific reason.
 - `AIRSPY_ADSB_OPTIONS` contains all of the rest of the settings which Airspy starts up with. The default value is set as `-v -t 90 -f 1 -e 4 -w 5 -P 8 -C 60 -E 20 -R rms -D 24,25,26,27,28,29,30,31` - for a full description of what these mean you can take a look at the [airspy-conf](https://github.com/wiedehopf/airspy-conf/blob/master/airspy_adsb.default) and [airspy_adsb](https://github.com/sdr-enthusiasts/airspy_adsb?tab=readme-ov-file#environment-variables) repositories which explain all of the settings. It is not recommended to change any of these unless you know why you are doing so.


### PR DESCRIPTION
add a note to say that using a raspi 4 or equivalent is best when using airspy