### PR TITLE
Updated OpenSky Network hostname.

### DIFF
--- a/opensky-network/opensky_installer.sh
+++ b/opensky-network/opensky_installer.sh
@@ -16,4 +16,4 @@ fi
 
 opensky_packet="opensky-feeder_${OPENSKY_VERSION}_$opensky_arch.deb"
 
-wget -O /tmp/OpenSky.deb https://old.opensky-network.org/files/firmware/$opensky_packet
+wget -O /tmp/OpenSky.deb https://opensky-network.org/files/firmware/$opensky_packet


### PR DESCRIPTION
OpenSky Networks has fixed the DNS entries for their packet servers, so we can start pointing to the main domain again now.