### PR TITLE
Add libncurses6 Dependency

### DIFF
--- a/adsb-exchange/Dockerfile.template
+++ b/adsb-exchange/Dockerfile.template
@@ -11,7 +11,7 @@ ENV ALT=
 ENV RECEIVER_HOST=dump1090-fa
 ENV RECEIVER_PORT=30005
 
-ARG PERM_INSTALL="curl socat gzip python3 python3-venv netcat-traditional dnsutils uuid-runtime zlib1g jq inotify-tools perl tini gettext-base"
+ARG PERM_INSTALL="curl socat gzip python3 python3-venv netcat-traditional dnsutils uuid-runtime zlib1g jq inotify-tools perl tini gettext-base libncurses6"
 
 RUN apt update && \
 	apt install -y $PERM_INSTALL && \


### PR DESCRIPTION
I wanted to test this change and noticed the container was not starting correctly due to this error:

adsb-exchange  [feed-adsbx]     /usr/bin/feed-adsbx: error while loading shared libraries: libncurses.so.6: cannot open shared object file: No such file or directory

Adding 'libncurses6' seems to resolve this issue.