### PR TITLE
Fix Dump978 & Dump1090 Builds

### DIFF
--- a/dump1090-fa/Dockerfile.template
+++ b/dump1090-fa/Dockerfile.template
@@ -46,6 +46,7 @@ WORKDIR /tmp
 
 RUN git clone --branch master --depth 1 --single-branch https://github.com/osmocom/rtl-sdr.git && \
 	cd rtl-sdr && \
+	git fetch --tags && \
 	git checkout tags/${RTLSDR_VERSION} && \
 	mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DDETACH_KERNEL_DRIVER=ON -DINSTALL_UDEV_RULES=ON ../ && make && make install && ldconfig && cd .. && \
 	dpkg-buildpackage -b && cd .. && \

--- a/dump978-fa/Dockerfile.template
+++ b/dump978-fa/Dockerfile.template
@@ -31,6 +31,7 @@ WORKDIR /tmp
 
 RUN git clone --branch master --depth 1 --single-branch https://github.com/osmocom/rtl-sdr.git && \
 	cd rtl-sdr && \
+	git fetch --tags && \
 	git checkout tags/${RTLSDR_VERSION} && \
 	mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DDETACH_KERNEL_DRIVER=ON -DINSTALL_UDEV_RULES=ON ../ && make && make install && ldconfig && cd .. && \
 	dpkg-buildpackage -b && cd .. && \


### PR DESCRIPTION
Something happened upstream where the git clone / git fetch operations in the Dockerfile.template for Dump978 and Dump1090 were failing.  The resulting errors for https://github.com/osmocom/rtl-sdr/ were showing as:

`error: pathspec 'tags/v2.0.2' did not match any file(s) known to git.`

I was able to find a fix by adding a line to git fetch all available tags before attempting checkout as mentioned here:

https://stackoverflow.com/questions/35691242/using-git-tags-cant-pull-new-tags

These now build correctly.