### PR TITLE
Fix Tar1090 Failures

### DIFF
--- a/tar1090/Dockerfile.template
+++ b/tar1090/Dockerfile.template
@@ -1,5 +1,5 @@
 # Uses base image from sdr-enthusiasts
-FROM ghcr.io/sdr-enthusiasts/docker-tar1090:latest AS base
+FROM ghcr.io/sdr-enthusiasts/docker-tar1090:latest-build-1315 AS base
 LABEL maintainer="https://github.com/ketilmo"
 
 # Copy our start script into correct place to be at the beginning of s6 startup


### PR DESCRIPTION
Pushing a release after 9/9 to your Balena fleet caused Tar1090 to go into a critical loop, spamming the following (#393 ):

```
 tar1090  fatal library error, lookup self
 tar1090  fatal library error, lookup self
 tar1090  unable to stop service (possibly not called from by s6 service)
```

This is tied to an upstream change made in ghcr.io/sdr-enthusiasts/docker-tar1090:latest-build-1316 or higher.  This fix sets the docker-tar1090 version to 1315 just before the loop issue occurs.

Albeit temporary, this at least allows use of Tar1090 until someone can help debug what started breaking in 1316.