### PR TITLE
fix: resolve tar1090 crash loop on ARM64/balenaOS

### DIFF
--- a/tar1090/Dockerfile.template
+++ b/tar1090/Dockerfile.template
@@ -4,7 +4,8 @@ LABEL maintainer="https://github.com/ketilmo"
 
 # Fix "fatal library error, lookup self" crash loop on ARM64/balenaOS (issue #408).
 # The base image's stop_service() uses `ps` to find the parent s6-supervise service name,
-# but procps 4.0.4 in Debian Trixie crashes on ARM64 during dlopen of libnuma.
+# but `ps` crashes on ARM64 during dlopen of libnuma after the base image updated glibc
+# from 2.36-9+deb12u10 to 2.36-9+deb12u13 (debian:bookworm-20250721-slim → 20250908-slim).
 # Fix: patch stop_service() to derive the service name from basename "$0" instead of ps.
 COPY patch-stop-service.sh /tmp/patch-stop-service.sh
 RUN bash /tmp/patch-stop-service.sh && rm /tmp/patch-stop-service.sh

--- a/tar1090/Dockerfile.template
+++ b/tar1090/Dockerfile.template
@@ -1,6 +1,13 @@
 # Uses base image from sdr-enthusiasts
-FROM ghcr.io/sdr-enthusiasts/docker-tar1090:latest-build-1315 AS base
+FROM ghcr.io/sdr-enthusiasts/docker-tar1090:latest AS base
 LABEL maintainer="https://github.com/ketilmo"
+
+# Fix "fatal library error, lookup self" crash loop on ARM64/balenaOS (issue #408).
+# The base image's stop_service() uses `ps` to find the parent s6-supervise service name,
+# but procps 4.0.4 in Debian Trixie crashes on ARM64 during dlopen of libnuma.
+# Fix: patch stop_service() to derive the service name from basename "$0" instead of ps.
+COPY patch-stop-service.sh /tmp/patch-stop-service.sh
+RUN bash /tmp/patch-stop-service.sh && rm /tmp/patch-stop-service.sh
 
 # Copy our start script into correct place to be at the beginning of s6 startup
 COPY 00-startup-checks /etc/s6-overlay/startup.d

--- a/tar1090/patch-stop-service.sh
+++ b/tar1090/patch-stop-service.sh
@@ -2,8 +2,11 @@
 set -e
 # Patch stop_service() in /scripts/common to avoid calling `ps` entirely.
 #
-# On ARM64/balenaOS, procps 4.0.4 (Debian Trixie) crashes with
-# "fatal library error, lookup self" when `ps` tries to dlopen libnuma.
+# On ARM64/balenaOS, `ps` crashes with "fatal library error, lookup self"
+# when it tries to dlopen libnuma. This started after the base image updated
+# glibc from 2.36-9+deb12u10 to 2.36-9+deb12u13 (bookworm-20250721-slim
+# to bookworm-20250908-slim, i.e. build-1315 → build-1316).
+#
 # The base image's stop_service() calls `ps` to walk the process tree and
 # find the parent s6-supervise service name, triggering an infinite crash loop.
 #

--- a/tar1090/patch-stop-service.sh
+++ b/tar1090/patch-stop-service.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+# Patch stop_service() in /scripts/common to avoid calling `ps` entirely.
+#
+# On ARM64/balenaOS, procps 4.0.4 (Debian Trixie) crashes with
+# "fatal library error, lookup self" when `ps` tries to dlopen libnuma.
+# The base image's stop_service() calls `ps` to walk the process tree and
+# find the parent s6-supervise service name, triggering an infinite crash loop.
+#
+# Instead of fixing `ps`, we replace the lookup entirely: s6 service scripts
+# live at /etc/s6-overlay/scripts/<service-name>, so basename "$0" gives us
+# the service name directly — no process tree walking needed.
+#
+# See: https://github.com/ketilmo/balena-ads-b/issues/408
+
+COMMON="/scripts/common"
+
+if [ ! -f "$COMMON" ]; then
+    echo "WARNING: $COMMON not found, skipping patch"
+    exit 0
+fi
+
+# Replace the ps-based service name lookup with basename.
+# Match the line containing both _SERVICE=$(ps and s6-supervise, replace the whole line.
+if grep -q '_SERVICE=\$(ps.*s6-supervise' "$COMMON"; then
+    sed -i '/_SERVICE=\$(ps.*s6-supervise/c\    _SERVICE=$(basename "$0")' "$COMMON"
+    echo "Patched stop_service() in /scripts/common successfully"
+else
+    echo "WARNING: ps-based _SERVICE line not found in $COMMON, skipping patch"
+fi


### PR DESCRIPTION
Had some free credits with Claude Code and decided to try it out on this issue. I know this is more of a workaround so perhaps I can dig deeper in the future. This fix allows us to use the latest tar1090 images moving forward.


## Summary

Fixes #408 — tar1090 container crash loops with `fatal library error, lookup self` on ARM64/balenaOS when using any base image newer than `build-1315`.

**Root cause:** The upstream base image (`docker-tar1090`) updated its Debian Bookworm base from `bookworm-20250721-slim` to `bookworm-20250908-slim`, which bumped glibc from `2.36-9+deb12u10` to `2.36-9+deb12u13`. After this update, the `ps` binary crashes on ARM64 during `dlopen` of `libnuma` with `fatal library error, lookup self`. The base image's `stop_service()` function in `/scripts/common` calls `ps` to walk the process tree and find the parent `s6-supervise` service name. When `ps` crashes, `_SERVICE` is empty, and `s6-svc` fails with `unable to stop service`, triggering an infinite restart loop.

**Fix:** Patch `stop_service()` at build time to derive the service name via `basename "$0"` instead of calling `ps`. This works because s6 service scripts live at `/etc/s6-overlay/scripts/<service-name>` — the basename matches the service directory name in `/run/service/<service-name>`. This avoids the broken `ps` binary entirely.

**Changes:**
- Unpin `docker-tar1090` from `latest-build-1315` back to `latest`
- Add `patch-stop-service.sh` that replaces the `ps`-based `_SERVICE` lookup with `basename "$0"` via `sed`
- Run the patch at build time and clean up the script

## Test plan

- [x] Deployed to RPi4 (ARM64) running balenaOS 6.10.24+rev3
- [x] Verified tar1090 container starts cleanly with zero `fatal library error` or `unable to stop service` messages
- [x] Verified all s6 services (readsb, tar1090, graphs1090, collectd, nginx, etc.) start and run normally
- [x] Verified graphs1090 completes initial graph generation
- [x] Compared logs against previous pinned release — fix eliminates all crash-related errors
- [x] Confirmed `libnuma1` is **not** required — the patch bypasses `ps` entirely
- [x] Verified tar1090 web UI loads at `:8078/tar1090/`
- [x] Verified graphs1090 web UI loads at `:8078/graphs1090/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)