### PR TITLE
Migrate base images from deprecated balenalib to Docker Official

### DIFF
--- a/adsb-exchange/Dockerfile.template
+++ b/adsb-exchange/Dockerfile.template
@@ -15,9 +15,9 @@ ENV DUMP978_ENABLED=false
 
 ARG PERM_INSTALL="curl ca-certificates socat gzip python3 python3-venv netcat dnsutils uuid-runtime zlib1g jq inotify-tools perl tini gettext-base"
 
-RUN apt update && \
-	apt install -y $PERM_INSTALL && \
-	apt clean && apt autoclean && apt autoremove && \
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $PERM_INSTALL && \
+	apt-get clean && apt-get autoremove -y && \
 	rm -rf /var/lib/apt/lists/*
 
 FROM base AS buildstep
@@ -30,8 +30,8 @@ ARG TEMP_INSTALL="git build-essential debhelper libncurses5-dev zlib1g-dev pytho
 
 WORKDIR /tmp
 
-RUN apt update && \
-	apt install -y $TEMP_INSTALL
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $TEMP_INSTALL
 
 RUN git clone --single-branch https://github.com/wiedehopf/mlat-client && \
 	cd mlat-client && \

--- a/adsb-exchange/Dockerfile.template
+++ b/adsb-exchange/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_ARCH%%-debian:bullseye AS base
+FROM debian:bullseye-slim AS base
 LABEL maintainer="https://github.com/ketilmo"
 
 EXPOSE 30154 30157 31003 
@@ -13,7 +13,7 @@ ENV RECEIVER_HOST=dump1090-fa
 ENV RECEIVER_PORT=30005
 ENV DUMP978_ENABLED=false
 
-ARG PERM_INSTALL="curl socat gzip python3 python3-venv netcat dnsutils uuid-runtime zlib1g jq inotify-tools perl tini gettext-base"
+ARG PERM_INSTALL="curl ca-certificates socat gzip python3 python3-venv netcat dnsutils uuid-runtime zlib1g jq inotify-tools perl tini gettext-base"
 
 RUN apt update && \
 	apt install -y $PERM_INSTALL && \

--- a/adsb-exchange/Dockerfile.template
+++ b/adsb-exchange/Dockerfile.template
@@ -13,7 +13,7 @@ ENV RECEIVER_HOST=dump1090-fa
 ENV RECEIVER_PORT=30005
 ENV DUMP978_ENABLED=false
 
-ARG PERM_INSTALL="curl ca-certificates socat gzip python3 python3-venv netcat dnsutils uuid-runtime zlib1g jq inotify-tools perl tini gettext-base"
+ARG PERM_INSTALL="curl ca-certificates socat gzip python3 python3-venv netcat dnsutils uuid-runtime zlib1g libncurses6 jq inotify-tools perl tini gettext-base"
 
 RUN apt-get update && \
 	apt-get install -y --no-install-recommends $PERM_INSTALL && \

--- a/adsb-exchange/start.sh
+++ b/adsb-exchange/start.sh
@@ -7,7 +7,7 @@ if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SER
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 # Verify that all the required variables are set before starting up the application.
@@ -245,14 +245,14 @@ if [ "$missing_variables" = "true" ]
 then
         echo "Required settings missing, aborting..."
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 if [ "$adsb" = "false" ] && [ "$mlat" = "false" ] && [ "$adsb_exchange" = "false" ]
 then
         echo "No services activated, aborting..."
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 if [ "$adsb" = "false" ]

--- a/airnav-radar/Dockerfile.template
+++ b/airnav-radar/Dockerfile.template
@@ -10,7 +10,7 @@ ENV ALT=
 ENV RECEIVER_HOST dump1090-fa
 ENV RECEIVER_PORT 30005
 
-ARG PERM_INSTALL="init-system-helpers dirmngr libcap2-bin tini gettext-base socat python3 python3-venv jq ca-certificates curl"
+ARG PERM_INSTALL="init-system-helpers dirmngr gnupg libcap2-bin tini gettext-base socat python3 python3-venv jq ca-certificates curl"
 
 RUN apt-get update && \
 	apt-get install -y --no-install-recommends $PERM_INSTALL && \

--- a/airnav-radar/Dockerfile.template
+++ b/airnav-radar/Dockerfile.template
@@ -12,9 +12,9 @@ ENV RECEIVER_PORT 30005
 
 ARG PERM_INSTALL="init-system-helpers dirmngr libcap2-bin tini gettext-base socat python3 python3-venv jq ca-certificates curl"
 
-RUN apt update && \
-	apt install -y $PERM_INSTALL && \
-	apt clean && apt autoclean && apt autoremove && \
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $PERM_INSTALL && \
+	apt-get clean && apt-get autoremove -y && \
 	rm -rf /var/lib/apt/lists/*
 
 FROM base AS buildstep
@@ -23,8 +23,8 @@ FROM base AS buildstep
 ARG MLAT_VERSION=28ae4f7409c9dfddd2bb8984baadce5d31fdc8e3
 ARG TEMP_INSTALL="build-essential debhelper python3-dev git" 
 
-RUN apt update && \
-	apt install -y $TEMP_INSTALL
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $TEMP_INSTALL
 
 WORKDIR /tmp
 

--- a/airnav-radar/Dockerfile.template
+++ b/airnav-radar/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_ARCH%%-debian:bookworm AS base
+FROM debian:bookworm-slim AS base
 LABEL maintainer="https://github.com/ketilmo"
 
 EXPOSE 32088
@@ -10,7 +10,7 @@ ENV ALT=
 ENV RECEIVER_HOST dump1090-fa
 ENV RECEIVER_PORT 30005
 
-ARG PERM_INSTALL="init-system-helpers dirmngr libcap2-bin tini gettext-base socat python3 python3-venv jq" 
+ARG PERM_INSTALL="init-system-helpers dirmngr libcap2-bin tini gettext-base socat python3 python3-venv jq ca-certificates curl"
 
 RUN apt update && \
 	apt install -y $PERM_INSTALL && \

--- a/airnav-radar/Dockerfile.template
+++ b/airnav-radar/Dockerfile.template
@@ -10,7 +10,7 @@ ENV ALT=
 ENV RECEIVER_HOST dump1090-fa
 ENV RECEIVER_PORT 30005
 
-ARG PERM_INSTALL="init-system-helpers dirmngr gnupg libcap2-bin tini gettext-base socat python3 python3-venv jq ca-certificates curl"
+ARG PERM_INSTALL="init-system-helpers dirmngr gnupg libcap2-bin tini gettext-base socat python3 python3-venv jq ca-certificates curl netbase"
 
 RUN apt-get update && \
 	apt-get install -y --no-install-recommends $PERM_INSTALL && \

--- a/airnav-radar/airnavradar_installer.sh
+++ b/airnav-radar/airnavradar_installer.sh
@@ -54,5 +54,5 @@ if dpkg-divert --list | grep -q "/usr/bin/systemctl"; then
 fi
 
 # Cleanup
-apt clean && apt autoclean && apt autoremove && \
+apt-get clean && apt-get autoremove -y && \
  rm -rf /var/lib/apt/lists/*

--- a/airnav-radar/start.sh
+++ b/airnav-radar/start.sh
@@ -7,7 +7,7 @@ if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SER
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 # Verify that all the required variables are set before starting up the application.
@@ -58,7 +58,7 @@ if [ "$missing_variables" = true ]
 then
         echo "Settings missing, aborting..."
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 # If UAT is enabled through config, enable it in rbfeed.

--- a/autohupr/Dockerfile.template
+++ b/autohupr/Dockerfile.template
@@ -1,7 +1,9 @@
-FROM balenalib/%%BALENA_ARCH%%-debian-node:bookworm AS base
+FROM node:22-bookworm-slim AS base
 LABEL maintainer="https://github.com/ketilmo"
 
-RUN install_packages tini
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends tini && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app
 

--- a/autohupr/start.sh
+++ b/autohupr/start.sh
@@ -7,7 +7,7 @@ if [[ ",$(echo -e "${ENABLED_SERVICES}" | tr -d '[:space:]')," != *",$BALENA_SER
         echo "$BALENA_SERVICE_NAME is not enabled. Sending request to stop the service:"
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 # Start app

--- a/dump1090-fa/Dockerfile.template
+++ b/dump1090-fa/Dockerfile.template
@@ -22,9 +22,9 @@ ENV AIRSPY_ADSB_STATS="false"
 
 ARG PERM_INSTALL="tini ca-certificates curl lighttpd gettext-base libusb-1.0-0 libbladerf2 libhackrf0 liblimesuite22.09-1 libsoapysdr0.8 libncurses6 libboost-system-dev libboost-program-options-dev libboost-regex-dev"
 
-RUN apt update && \
-	apt install -y $PERM_INSTALL && \
-	apt clean && apt autoclean && apt autoremove && \
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $PERM_INSTALL && \
+	apt-get clean && apt-get autoremove -y && \
 	rm -rf /var/lib/apt/lists/*
 
 FROM base AS buildstep
@@ -39,8 +39,8 @@ ARG BEAST_SPLITTER_VERSION=v10.2
 ARG AIRSPY_VERSION=7f07ea95311cceb7eb37cbaf965b65faae5551bd
 ARG TEMP_INSTALL="git build-essential fakeroot cmake debhelper pkg-config libncurses5-dev libbladerf-dev libhackrf-dev liblimesuite-dev libusb-1.0-0-dev libsoapysdr-dev librtlsdr-dev apt-utils apt-transport-https debhelper wget"
 
-RUN apt update && \
-	apt install -y $TEMP_INSTALL
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $TEMP_INSTALL
 
 WORKDIR /tmp
 

--- a/dump1090-fa/Dockerfile.template
+++ b/dump1090-fa/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_ARCH%%-debian:bookworm AS base
+FROM debian:bookworm-slim AS base
 LABEL maintainer="https://github.com/ketilmo"
 
 EXPOSE 30001 30002 30003 30004 30005 30102 30104 30105 30106 8080
@@ -20,7 +20,7 @@ ENV AIRSPY_ADSB_GAIN="auto"
 ENV AIRSPY_ADSB_SAMPLE_RATE="12"
 ENV AIRSPY_ADSB_STATS="false"
 
-ARG PERM_INSTALL="tini lighttpd gettext-base libusb-1.0-0 libbladerf2 libhackrf0 liblimesuite22.09-1 libsoapysdr0.8 libncurses6 libboost-system-dev libboost-program-options-dev libboost-regex-dev"
+ARG PERM_INSTALL="tini ca-certificates curl lighttpd gettext-base libusb-1.0-0 libbladerf2 libhackrf0 liblimesuite22.09-1 libsoapysdr0.8 libncurses6 libboost-system-dev libboost-program-options-dev libboost-regex-dev"
 
 RUN apt update && \
 	apt install -y $PERM_INSTALL && \

--- a/dump1090-fa/start.sh
+++ b/dump1090-fa/start.sh
@@ -8,7 +8,7 @@ if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SER
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
         echo " "
-        balena-idle
+        sleep infinity
 fi
 # Verify that all the required variables are set before starting up the application.
 
@@ -31,7 +31,7 @@ if [ "$missing_variables" = true ]
 then
         echo "Settings missing, aborting..."
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 echo "Settings verified, proceeding with startup."
@@ -45,7 +45,7 @@ then
 	echo "DUMP1090 idle not set. Continuing container startup."
 else
 	echo "DUMP1090 idle set. Idling container to allow setting rtlsdr serial."
- 	balena-idle
+ 	sleep infinity
 fi
 
 radio_device_lower=$(echo "${RADIO_DEVICE_TYPE}" | tr '[:upper:]' '[:lower:]')

--- a/dump978-fa/Dockerfile.template
+++ b/dump978-fa/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_ARCH%%-debian:bookworm AS base
+FROM debian:bookworm-slim AS base
 LABEL maintainer="https://github.com/ketilmo"
 
 EXPOSE 30978 30979 8978
@@ -7,7 +7,7 @@ ENV DUMP978_DEVICE=00000978
 ENV DUMP978_ENABLED=false
 ENV REBOOT_DEVICE_ON_SERVICE_EXIT=""
 
-ARG PERM_INSTALL="tini libboost-program-options-dev libusb-1.0-0 lighttpd swig gettext-base libboost-filesystem1.74.0 libboost-regex1.74.0 libboost-system1.74.0 libsoapysdr0.8"
+ARG PERM_INSTALL="tini ca-certificates curl libboost-program-options-dev libusb-1.0-0 lighttpd swig gettext-base libboost-filesystem1.74.0 libboost-regex1.74.0 libboost-system1.74.0 libsoapysdr0.8"
 
 RUN apt update && \
 	apt install -y $PERM_INSTALL && \

--- a/dump978-fa/Dockerfile.template
+++ b/dump978-fa/Dockerfile.template
@@ -9,9 +9,9 @@ ENV REBOOT_DEVICE_ON_SERVICE_EXIT=""
 
 ARG PERM_INSTALL="tini ca-certificates curl libboost-program-options-dev libusb-1.0-0 lighttpd swig gettext-base libboost-filesystem1.74.0 libboost-regex1.74.0 libboost-system1.74.0 libsoapysdr0.8"
 
-RUN apt update && \
-	apt install -y $PERM_INSTALL && \
-	apt clean && apt autoclean && apt autoremove && \
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $PERM_INSTALL && \
+	apt-get clean && apt-get autoremove -y && \
 	rm -rf /var/lib/apt/lists/*
 
 FROM base AS buildstep
@@ -24,8 +24,8 @@ ARG SOAPYRTLSDR_VERSION=b1f568d1b57cc973a1d2ee49be68d0d748d164e4
 ARG DUMP978_VERSION=v10.2
 ARG TEMP_INSTALL="build-essential cmake git debhelper pkg-config libboost-system-dev libboost-regex-dev libusb-1.0-0-dev libboost-filesystem-dev libboost-program-options-dev debhelper libsoapysdr-dev"
 
-RUN apt update && \
-	apt install -y $TEMP_INSTALL
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $TEMP_INSTALL
 
 WORKDIR /tmp
 

--- a/dump978-fa/start.sh
+++ b/dump978-fa/start.sh
@@ -8,7 +8,7 @@ if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SER
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 # Check if service has been enabled through the UAT_ENABLED environment variable.
@@ -17,7 +17,7 @@ if ! [[ "$UAT_ENABLED" = "true" ]]; then
         echo "$BALENA_SERVICE_NAME is not enabled. Sending request to stop the service:"
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 # Verify that all the required variables are set before starting up the application.
@@ -42,7 +42,7 @@ if [ "$missing_variables" = true ]
 then
         echo "Settings missing, aborting..."
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 echo "Settings verified, proceeding with startup."
@@ -56,7 +56,7 @@ then
 	echo "DUMP978 idle not set. Continuing container startup."
 else
 	echo "DUMP978 idle set. Idling container to allow setting rtlsdr serial."
- 	balena-idle
+ 	sleep infinity
 fi
 
 # rtl-sdr bias tee enable (this container only supports rtl-sdr so no need to check radio device type)

--- a/fr24feed/Dockerfile.template
+++ b/fr24feed/Dockerfile.template
@@ -11,17 +11,17 @@ ENV RECEIVER_PORT=30005
 
 ARG PERM_INSTALL="gettext-base tini ca-certificates curl"
 
-RUN apt update && \
-	apt install -y $PERM_INSTALL && \
-	apt clean && apt autoclean && apt autoremove && \
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $PERM_INSTALL && \
+	apt-get clean && apt-get autoremove -y && \
 	rm -rf /var/lib/apt/lists/*
 
 FROM base AS buildstep
 
 ARG TEMP_INSTALL="wget"
 
-RUN apt update && \
-	apt install -y $TEMP_INSTALL
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $TEMP_INSTALL
 
 WORKDIR /tmp
 

--- a/fr24feed/Dockerfile.template
+++ b/fr24feed/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_ARCH%%-debian:bookworm AS base
+FROM debian:bookworm-slim AS base
 LABEL maintainer="https://github.com/ketilmo"
 
 EXPOSE 8754
@@ -9,7 +9,7 @@ ENV FR24_KEY=
 ENV RECEIVER_HOST=dump1090-fa
 ENV RECEIVER_PORT=30005
 
-ARG PERM_INSTALL="gettext-base tini"
+ARG PERM_INSTALL="gettext-base tini ca-certificates curl"
 
 RUN apt update && \
 	apt install -y $PERM_INSTALL && \

--- a/fr24feed/fr24feed_installer.sh
+++ b/fr24feed/fr24feed_installer.sh
@@ -4,22 +4,22 @@ set -e
 arch="$(dpkg --print-architecture)"
 echo System Architecture: $arch
 
-if [ "$arch" = "arm64" ]; then
+if [ "$arch" = "arm64" ]; then 
 	dpkg --add-architecture armhf
 	fr24feed_arch=armhf
-	fr24feed_url="http://repo.feed.flightradar24.com/rpi_binaries/"
-
-elif [ "$arch" = "amd64" ]; then
+	fr24feed_url="https://repo-feed.flightradar24.com/rpi_binaries/"
+	
+elif [ "$arch" = "amd64" ]; then 
 	fr24feed_arch=amd64
-	fr24feed_url="http://repo.feed.flightradar24.com/linux_binaries/"
-else
+	fr24feed_url="https://repo-feed.flightradar24.com/linux_binaries/"
+else 
 	fr24feed_arch=armhf
-	fr24feed_url="http://repo.feed.flightradar24.com/rpi_binaries/"
+	fr24feed_url="https://repo-feed.flightradar24.com/rpi_binaries/"
 fi
 
 cd /tmp
 
-fr24feed_installer="fr24feed_${FR24FEED_VERSION}_$fr24feed_arch.tgz"
+fr24feed_installer="fr24feed_${FR24FEED_VERSION}_$fr24feed_arch.tgz" 
 
 wget -O fr24feed.tgz $fr24feed_url$fr24feed_installer
 

--- a/fr24feed/fr24feed_installer.sh
+++ b/fr24feed/fr24feed_installer.sh
@@ -4,22 +4,22 @@ set -e
 arch="$(dpkg --print-architecture)"
 echo System Architecture: $arch
 
-if [ "$arch" = "arm64" ]; then 
+if [ "$arch" = "arm64" ]; then
 	dpkg --add-architecture armhf
 	fr24feed_arch=armhf
-	fr24feed_url="https://repo-feed.flightradar24.com/rpi_binaries/"
-	
-elif [ "$arch" = "amd64" ]; then 
+	fr24feed_url="http://repo.feed.flightradar24.com/rpi_binaries/"
+
+elif [ "$arch" = "amd64" ]; then
 	fr24feed_arch=amd64
-	fr24feed_url="https://repo-feed.flightradar24.com/linux_binaries/"
-else 
+	fr24feed_url="http://repo.feed.flightradar24.com/linux_binaries/"
+else
 	fr24feed_arch=armhf
-	fr24feed_url="https://repo-feed.flightradar24.com/rpi_binaries/"
+	fr24feed_url="http://repo.feed.flightradar24.com/rpi_binaries/"
 fi
 
 cd /tmp
 
-fr24feed_installer="fr24feed_${FR24FEED_VERSION}_$fr24feed_arch.tgz" 
+fr24feed_installer="fr24feed_${FR24FEED_VERSION}_$fr24feed_arch.tgz"
 
 wget -O fr24feed.tgz $fr24feed_url$fr24feed_installer
 

--- a/fr24feed/start.sh
+++ b/fr24feed/start.sh
@@ -7,7 +7,7 @@ if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SER
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 # Verify that all the required variables are set before starting up the application.
@@ -34,7 +34,7 @@ if [ "$missing_variables" = true ]
 then
         echo "Settings missing, aborting..."
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 echo "Settings verified, proceeding with startup."

--- a/kiosk/start.sh
+++ b/kiosk/start.sh
@@ -7,7 +7,7 @@ if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SER
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 # Start app

--- a/mlat-client/Dockerfile.template
+++ b/mlat-client/Dockerfile.template
@@ -11,9 +11,9 @@ ENV RECEIVER_PORT=30005
 
 ARG PERM_INSTALL="tini python3 python3-venv ca-certificates curl"
 
-RUN apt update && \
-	apt install -y $PERM_INSTALL && \
-	apt clean && apt autoclean && apt autoremove && \
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $PERM_INSTALL && \
+	apt-get clean && apt-get autoremove -y && \
 	rm -rf /var/lib/apt/lists/*
 
 FROM base AS buildstep
@@ -22,8 +22,8 @@ FROM base AS buildstep
 ARG MLAT_VERSION=28ae4f7409c9dfddd2bb8984baadce5d31fdc8e3
 ARG TEMP_INSTALL="build-essential debhelper python3-dev git" 
 
-RUN apt update && \
-	apt install -y $TEMP_INSTALL
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $TEMP_INSTALL
 
 WORKDIR /tmp
 

--- a/mlat-client/Dockerfile.template
+++ b/mlat-client/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_ARCH%%-debian:bookworm AS base
+FROM debian:bookworm-slim AS base
 LABEL maintainer="https://github.com/ketilmo"
 
 ENV LAT=
@@ -9,7 +9,7 @@ ENV MLAT_SERVER=
 ENV RECEIVER_HOST=dump1090-fa
 ENV RECEIVER_PORT=30005
 
-ARG PERM_INSTALL="tini python3 python3-venv" 
+ARG PERM_INSTALL="tini python3 python3-venv ca-certificates curl"
 
 RUN apt update && \
 	apt install -y $PERM_INSTALL && \

--- a/mlat-client/start.sh
+++ b/mlat-client/start.sh
@@ -7,7 +7,7 @@ if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SER
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 # Verify that all the required variables are set before starting up the application.
@@ -36,7 +36,7 @@ if [ "$missing_variables" = true ]
 then
         echo "Settings missing, aborting..."
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 echo "Settings verified, proceeding with startup."

--- a/opensky-network/Dockerfile.template
+++ b/opensky-network/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_ARCH%%-debian:bookworm AS base
+FROM debian:bookworm-slim AS base
 LABEL maintainer="https://github.com/ketilmo"
 
 ENV OPENSKY_USERNAME=
@@ -10,7 +10,7 @@ ENV ALT=
 ENV RECEIVER_HOST=dump1090-fa
 ENV RECEIVER_PORT=30005
 
-ARG PERM_INSTALL="perl gettext-base tini expect" 
+ARG PERM_INSTALL="perl gettext-base tini expect ca-certificates curl"
 
 RUN apt update && \
 	apt install -y $PERM_INSTALL && \

--- a/opensky-network/Dockerfile.template
+++ b/opensky-network/Dockerfile.template
@@ -12,9 +12,9 @@ ENV RECEIVER_PORT=30005
 
 ARG PERM_INSTALL="perl gettext-base tini expect ca-certificates curl"
 
-RUN apt update && \
-	apt install -y $PERM_INSTALL && \
-	apt clean && apt autoclean && apt autoremove && \
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $PERM_INSTALL && \
+	apt-get clean && apt-get autoremove -y && \
 	rm -rf /var/lib/apt/lists/*
 
 FROM base AS buildstep
@@ -23,8 +23,8 @@ FROM base AS buildstep
 ARG OPENSKY_VERSION=2.1.7-1
 ARG TEMP_INSTALL="wget" 
 
-RUN apt update && \
-	apt install -y $TEMP_INSTALL
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $TEMP_INSTALL
 
 WORKDIR /tmp
 

--- a/opensky-network/start.sh
+++ b/opensky-network/start.sh
@@ -7,7 +7,7 @@ if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SER
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 # Verify that all the required variables are set before starting up the application.
@@ -35,7 +35,7 @@ if [ "$missing_variables" = true ]
 then
         echo "Settings missing, aborting..."
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 echo "Settings verified, proceeding with startup."
@@ -63,7 +63,7 @@ if [ "$missing_variables" = true ]
 then
         echo "OpenSky Network Serial is missing, aborting..."
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 envsubst < /var/lib/openskyd/conf.tpl/05-serial.conf.tpl> /var/lib/openskyd/conf.d/05-serial.conf

--- a/piaware/Dockerfile.template
+++ b/piaware/Dockerfile.template
@@ -11,7 +11,7 @@ ENV UAT_RECEIVER_PORT 30978
 ENV RECEIVER_MLAT_PORT 30104
 ENV DUMP978_ENABLED=false
 
-ARG PERM_INSTALL="tini ca-certificates curl net-tools tclx8.4 tcllib itcl3 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0 libboost-system1.74.0 libexpat1 expect openssl rsyslog"
+ARG PERM_INSTALL="tini ca-certificates curl net-tools tclx8.4 tcllib itcl3 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0 libboost-system1.74.0 libexpat1 libreadline8 expect openssl rsyslog"
 
 RUN apt-get update && \
 	apt-get install -y --no-install-recommends $PERM_INSTALL && \

--- a/piaware/Dockerfile.template
+++ b/piaware/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_ARCH%%-debian:bookworm AS base
+FROM debian:bookworm-slim AS base
 LABEL maintainer="https://github.com/ketilmo"
 
 EXPOSE 30105 30106
@@ -11,7 +11,7 @@ ENV UAT_RECEIVER_PORT 30978
 ENV RECEIVER_MLAT_PORT 30104
 ENV DUMP978_ENABLED=false
 
-ARG PERM_INSTALL="tini net-tools tclx8.4 tcllib itcl3 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0 libboost-system1.74.0 libexpat1 expect openssl rsyslog"
+ARG PERM_INSTALL="tini ca-certificates curl net-tools tclx8.4 tcllib itcl3 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0 libboost-system1.74.0 libexpat1 expect openssl rsyslog"
 
 RUN apt update && \
 	apt install -y $PERM_INSTALL && \

--- a/piaware/Dockerfile.template
+++ b/piaware/Dockerfile.template
@@ -13,9 +13,9 @@ ENV DUMP978_ENABLED=false
 
 ARG PERM_INSTALL="tini ca-certificates curl net-tools tclx8.4 tcllib itcl3 libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-regex1.74.0 libboost-system1.74.0 libexpat1 expect openssl rsyslog"
 
-RUN apt update && \
-	apt install -y $PERM_INSTALL && \
-	apt clean && apt autoclean && apt autoremove && \
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $PERM_INSTALL && \
+	apt-get clean && apt-get autoremove -y && \
 	rm -rf /var/lib/apt/lists/*
 
 FROM base AS buildstep
@@ -24,8 +24,8 @@ FROM base AS buildstep
 ARG PIAWARE_VERSION=v10.2
 ARG TEMP_INSTALL="wget devscripts build-essential debhelper tcl8.6-dev autoconf python3-dev python3-venv python3-setuptools python3-wheel python3-build python3-pip patchelf debhelper libz-dev git libssl-dev tcl-dev chrpath libboost-system-dev libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev"
 
-RUN apt update && \
-	apt install -y $TEMP_INSTALL
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $TEMP_INSTALL
 
 WORKDIR /tmp
 

--- a/piaware/start.sh
+++ b/piaware/start.sh
@@ -7,7 +7,7 @@ if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SER
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 # Verify that all the required variables are set before starting up the application.
@@ -36,7 +36,7 @@ if [ "$missing_variables" = true ]
 then
         echo "Settings missing, aborting..."
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 echo "Settings verified, proceeding with startup."

--- a/planefinder/Dockerfile.template
+++ b/planefinder/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_ARCH%%-debian:bullseye AS base
+FROM debian:bullseye-slim AS base
 LABEL maintainer="https://github.com/ketilmo"
 
 EXPOSE 30053
@@ -10,7 +10,7 @@ ENV GOOGLE_MAPS_API_KEY=
 ENV RECEIVER_HOST=dump1090-fa
 ENV RECEIVER_PORT=30005
 
-ARG PERM_INSTALL="gettext-base wget tini" 
+ARG PERM_INSTALL="gettext-base wget tini ca-certificates curl"
 
 RUN apt update && \
 	apt install -y $PERM_INSTALL && \

--- a/planefinder/Dockerfile.template
+++ b/planefinder/Dockerfile.template
@@ -12,9 +12,9 @@ ENV RECEIVER_PORT=30005
 
 ARG PERM_INSTALL="gettext-base wget tini ca-certificates curl"
 
-RUN apt update && \
-	apt install -y $PERM_INSTALL && \
-	apt clean && apt autoclean && apt autoremove && \
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $PERM_INSTALL && \
+	apt-get clean && apt-get autoremove -y && \
 	rm -rf /var/lib/apt/lists/*
 
 FROM base AS buildstep

--- a/planefinder/planefinder_installer.sh
+++ b/planefinder/planefinder_installer.sh
@@ -28,6 +28,6 @@ wget -O PlaneFinder.deb http://client.planefinder.net/$planefinder_packet
 dpkg -i PlaneFinder.deb
 rm -rf PlaneFinder.deb
 
-apt purge wget && \
-	apt clean && apt autoclean && apt autoremove && \
+apt-get purge -y wget && \
+	apt-get clean && apt-get autoremove -y && \
 	rm -rf /var/lib/apt/lists/*

--- a/planefinder/start.sh
+++ b/planefinder/start.sh
@@ -7,7 +7,7 @@ if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SER
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 # Verify that all the required variables are set before starting up the application.
@@ -34,7 +34,7 @@ if [ "$missing_variables" = true ]
 then
         echo "Settings missing, aborting..."
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 echo "Settings verified, proceeding with startup."

--- a/planewatch/Dockerfile.template
+++ b/planewatch/Dockerfile.template
@@ -12,8 +12,8 @@ ARG MLAT_CLIENT_VERSION=v0.2.13
 # install build step pre-requs
 ARG TEMP_INSTALL="python3-dev python3-venv"
 WORKDIR /tmp
-RUN apt update && \
-	apt install -y $TEMP_INSTALL
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $TEMP_INSTALL
 
 # build pw-feeder binary from source
 WORKDIR /tmp
@@ -59,9 +59,9 @@ EXPOSE 30105
 
 # install pre-requisite packages
 ARG PERM_INSTALL="python3 tini ca-certificates curl"
-RUN apt update && \
-	apt install -y $PERM_INSTALL && \
-	apt clean && apt autoclean && apt autoremove && \
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $PERM_INSTALL && \
+	apt-get clean && apt-get autoremove -y && \
 	rm -rf /var/lib/apt/lists/*
 
 # copy pw-feeder binary from buildstep

--- a/planewatch/Dockerfile.template
+++ b/planewatch/Dockerfile.template
@@ -1,24 +1,5 @@
-FROM balenalib/%%BALENA_ARCH%%-debian-golang:bookworm AS buildstep
+FROM golang:1.25.4-bookworm AS buildstep
 LABEL maintainer="https://github.com/ketilmo"
-
-# Update go version
-ENV GO_VERSION 1.25.4
-
-ARG BALENA_ARCH=%%BALENA_ARCH%%
-
-# Detect architecture and set appropriate Go download URL
-RUN case $BALENA_ARCH in \
-        "amd64")  GOARCH=amd64; GOHASH="9fa5ffeda4170de60f67f3aa0f824e426421ba724c21e133c1e35d6159ca1bec" ;; \
-        "aarch64")  GOARCH=arm64; GOHASH="a68e86d4b72c2c2fecf7dfed667680b6c2a071221bbdb6913cf83ce3f80d9ff0" ;; \
-        "armv7hf") GOARCH=armv6l; GOHASH="ff86a6406310d840edb170f539a51a7efac0ac2b2f84527b1b2bf5935fc4ab6d" ;; \
-        *)        echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
-    esac && \
-    rm -rf /usr/local/go && \
-    mkdir -p /usr/local/go && \
-    curl -SLO "https://go.dev/dl/go${GO_VERSION}.linux-${GOARCH}.tar.gz" && \
-    echo "${GOHASH}  go${GO_VERSION}.linux-${GOARCH}.tar.gz" | sha256sum -c - && \
-    tar -xzf "go${GO_VERSION}.linux-${GOARCH}.tar.gz" -C /usr/local/go --strip-components=1 && \
-    rm -f go${GO_VERSION}.linux-${GOARCH}.tar.gz
 
 # specify plane.watch pw-feeder version
 # renovate: datasource=github-tags depName=plane-watch/pw-feeder versioning=loose
@@ -64,7 +45,7 @@ RUN curl -so lets-encrypt-e5.crt https://letsencrypt.org/certs/2024/e5.pem && \
     curl -so lets-encrypt-r13.crt https://letsencrypt.org/certs/2024/r13.pem && \
     curl -so lets-encrypt-r14.crt https://letsencrypt.org/certs/2024/r14.pem
 
-FROM balenalib/%%BALENA_ARCH%%-debian:bookworm AS release
+FROM debian:bookworm-slim AS release
 
 ENV LAT=
 ENV LON=
@@ -77,7 +58,7 @@ ENV RECEIVER_PORT 30005
 EXPOSE 30105
 
 # install pre-requisite packages
-ARG PERM_INSTALL="python3 tini"
+ARG PERM_INSTALL="python3 tini ca-certificates curl"
 RUN apt update && \
 	apt install -y $PERM_INSTALL && \
 	apt clean && apt autoclean && apt autoremove && \

--- a/planewatch/start.sh
+++ b/planewatch/start.sh
@@ -7,7 +7,7 @@ if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SER
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 # Verify that all the required variables are set before starting up the application.
@@ -34,7 +34,7 @@ if [ "$missing_variables" = true ]
 then
         echo "Settings missing, aborting..."
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 echo "Settings verified, proceeding with startup."

--- a/traefik/Dockerfile.template
+++ b/traefik/Dockerfile.template
@@ -5,9 +5,9 @@ EXPOSE 80 8080 443
 
 ARG PERM_INSTALL="gettext-base tini ca-certificates curl"
 
-RUN apt update && \
-	apt install -y $PERM_INSTALL && \
-	apt clean && apt autoclean && apt autoremove && \
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $PERM_INSTALL && \
+	apt-get clean && apt-get autoremove -y && \
 	rm -rf /var/lib/apt/lists/*
 
 FROM base AS buildstep
@@ -19,8 +19,8 @@ ARG TEMP_INSTALL="wget"
 COPY traefik_installer.sh /tmp
 WORKDIR /tmp
 
-RUN apt update && \
-	apt install -y $TEMP_INSTALL && \
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $TEMP_INSTALL && \
 	chmod +x /tmp/traefik_installer.sh && \
 	./traefik_installer.sh && \
 	rm -rf traefik_installer.sh

--- a/traefik/Dockerfile.template
+++ b/traefik/Dockerfile.template
@@ -1,9 +1,9 @@
-FROM balenalib/%%BALENA_ARCH%%-debian:bookworm AS base
+FROM debian:bookworm-slim AS base
 LABEL maintainer="https://github.com/ketilmo"
 
 EXPOSE 80 8080 443
 
-ARG PERM_INSTALL="gettext-base tini" 
+ARG PERM_INSTALL="gettext-base tini ca-certificates curl"
 
 RUN apt update && \
 	apt install -y $PERM_INSTALL && \

--- a/traefik/start.sh
+++ b/traefik/start.sh
@@ -7,7 +7,7 @@ if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SER
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 # Start traefik and put it in the background.

--- a/wifi-connect/Dockerfile.template
+++ b/wifi-connect/Dockerfile.template
@@ -1,10 +1,10 @@
-ARG BALENA_ARCH=%%BALENA_ARCH%%
-
-FROM balenalib/$BALENA_ARCH-debian:bookworm
+FROM debian:bookworm-slim
 LABEL maintainer="https://github.com/ketilmo"
 ARG BALENA_ARCH=%%BALENA_ARCH%%
 
-RUN install_packages dnsmasq wireless-tools
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends dnsmasq wireless-tools curl ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 # renovate: datasource=github-releases depName=balena-os/wifi-connect
 ARG WIFI_CONNECT_VERSION=v4.11.84

--- a/wifi-connect/start.sh
+++ b/wifi-connect/start.sh
@@ -8,7 +8,7 @@ if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SER
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 # Optional step - it takes couple of seconds (or longer) to establish a WiFi connection
@@ -39,4 +39,4 @@ else
 fi
 
 # Start your application here.
-balena-idle
+sleep infinity

--- a/wingbits/Dockerfile.template
+++ b/wingbits/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_ARCH%%-debian:bookworm AS base
+FROM debian:bookworm-slim AS base
 LABEL maintainer="https://github.com/ketilmo"
 
 EXPOSE 30154
@@ -14,7 +14,7 @@ ENV WINGBITS_CONFIG_VERSION=0.2.1
 ENV WINGBITS_COMMIT_ID=v1.10.25
 ENV WINGBITS_DATE=2026-04-28T10:50:44.608968853Z
 
-ARG PERM_INSTALL="curl gettext-base tini ncurses-dev zlib1g jq python3-pip python3-venv wget"
+ARG PERM_INSTALL="curl ca-certificates gettext-base tini ncurses-dev zlib1g jq python3-pip python3-venv wget"
 
 RUN apt update && \
 	apt install -y $PERM_INSTALL && \

--- a/wingbits/Dockerfile.template
+++ b/wingbits/Dockerfile.template
@@ -16,9 +16,9 @@ ENV WINGBITS_DATE=2026-04-28T10:50:44.608968853Z
 
 ARG PERM_INSTALL="curl ca-certificates gettext-base tini ncurses-dev zlib1g jq python3-pip python3-venv wget"
 
-RUN apt update && \
-	apt install -y $PERM_INSTALL && \
-	apt clean && apt autoclean && apt autoremove && \
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $PERM_INSTALL && \
+	apt-get clean && apt-get autoremove -y && \
 	rm -rf /var/lib/apt/lists/*
 
 FROM base AS buildstep
@@ -29,8 +29,8 @@ ARG TEMP_INSTALL="git gcc make libusb-1.0-0-dev build-essential debhelper zlib1g
 
 WORKDIR /tmp
 
-RUN apt update && \
-	apt install -y $TEMP_INSTALL
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends $TEMP_INSTALL
 
 WORKDIR /tmp
 

--- a/wingbits/start.sh
+++ b/wingbits/start.sh
@@ -7,7 +7,7 @@ if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SER
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 # Verify that all the required variables are set before starting up the application.
@@ -32,7 +32,7 @@ if [ "$missing_variables" = true ]
 then
         echo "Settings missing, aborting..."
         echo " "
-        balena-idle
+        sleep infinity
 fi
 
 # Check for idle variable (for manual flash of GeoSigner)
@@ -41,7 +41,7 @@ then
 	echo "Wingbits idle not set. Continuing container startup."
 else
 	echo "Wingbits idle set. Idling container to allow manually flashing GeoSigner."
- 	balena-idle
+ 	sleep infinity
 fi
 
 echo "Settings verified, proceeding with startup."


### PR DESCRIPTION
## Why

Balena [stopped publishing updates to the `balenalib/*` registry in 2025](https://blog.balena.io/deprecate-balenalib-images/) and [recommends Docker Official images instead](https://docs.balena.io/reference/base-images/balena-base-images). This PR completes that migration for all in-scope services.

## What

Five commits, ordered as problem → solution:

1. **`build: replace deprecated balenalib base images with Docker Official`** — Bulk swap of the `FROM` line in 13 Dockerfiles:
   - `debian:bookworm-slim`: dump1090-fa, dump978-fa, piaware, fr24feed, opensky-network, airnav-radar, wingbits, traefik, mlat-client, planewatch (release stage)
   - `debian:bullseye-slim`: planefinder, adsb-exchange (kept on bullseye for binary/lib soversion compatibility — distro bump is a separate decision)
   - `golang:1.25.4-bookworm`: planewatch buildstep (drops the manual Go download block since Go ships in the image)
   - `node:22-bookworm-slim`: autohupr (also replaces `install_packages` with `apt-get install`)

   Adds `ca-certificates` and `curl` to `PERM_INSTALL` where missing — every `start.sh` calls the Balena supervisor API over curl, and balenalib shipped both by default while debian-slim does not.

2. **`chore: replace balena-idle with sleep infinity, migrate wifi-connect base image`** — `balena-idle` was a balenalib-specific shim that doesn't exist on debian-slim. Replaces 31 occurrences across 14 services with `sleep infinity`, which works on any base image. Also brings wifi-connect into scope (previously gated for an unrelated upstream PR that has now landed).

3. **`build: add --no-install-recommends to apt-get install (avoids .deb collisions)`** — balenalib's bookworm shipped apt configured to disable Recommends globally and assume-yes; debian-slim ships stock apt with neither default. The dump978-fa build surfaced this concretely: `libsoapysdr0.8` (in PERM_INSTALL) pulled in `soapysdr0.8-module-rtlsdr` as a Recommends, and the buildstep's hand-built `soapysdr0.7-module-rtlsdr_*.deb` then collided on `/usr/lib/x86_64-linux-gnu/SoapySDR/modules0.8/librtlsdrSupport.so`. Adds `--no-install-recommends` to all 25 apt install sites across the 14 in-scope Dockerfiles, switches `apt` → `apt-get`, and modernizes the cleanup chain.

4. **`build: declare runtime deps that --no-install-recommends no longer pulls`** — Side effect of (3): runtime packages balenalib pulled in as Recommends are now missing.
   - **piaware**: `libreadline8` (piaware Depends on it at runtime; previously transitive via tcllib/itcl3)
   - **airnav-radar**: `gnupg` (`airnavradar_installer.sh` uses `apt-key adv` which needs the `gpg` binary; `dirmngr` alone doesn't provide it)
   - **planefinder**: installer cleanup switched to `apt-get` with `-y` (balenalib had assume-yes baked into apt config; debian-slim doesn't, so prompts hit EOF on stdin in non-TTY Docker builds and abort via `set -e`)
   - **airnav-radar**: same `-y` fix preemptively applied to the installer cleanup line

5. **`fix: restore missing runtime libs dropped by slim base image migration`** — Two more deps surfaced during runtime testing:
   - **adsb-exchange**: `libncurses6` (readsb links against `libncurses.so.6` at runtime; build had only `libncurses5-dev`)
   - **airnav-radar**: `netbase` (debian-slim omits netbase, so `/etc/services` is absent; `rbfeeder`'s `getaddrinfo` returns `EAI_SERVICE` without it)

## Verification

- **Static:** `git grep` confirms zero remaining references to `balenalib/`, `install_packages`, or `balena-idle` anywhere in the tree.
- **Runtime:** built and deployed via `balena push` on amd64; all containers come up clean.

## Out of scope

- **kiosk** uses `bh.cr/balenalabs/browser-…` (balenalabs-maintained, not balenalib, not deprecated).
- **tar1090** uses `ghcr.io/sdr-enthusiasts/docker-tar1090` (external, unaffected).

## Notes for reviewers

- The 5-commit structure is intentional: each commit captures a distinct phase of the migration, and the cause-and-effect chain between commits 3→4→5 is useful for future `git bisect`. Squash-on-merge is fine if you prefer a single commit on `master`.
- All target architectures (`armv7hf`, `aarch64`, `amd64`) are covered by Docker Official's multi-arch manifest lists, so no `%%BALENA_ARCH%%` templating is needed in `FROM` lines anymore.
