### PR TITLE
wingbits: remove JSON net connector

### DIFF
--- a/wingbits/start.sh
+++ b/wingbits/start.sh
@@ -139,7 +139,7 @@ fi
 # Start wingbits feeder first, then readsb-wingbits after a 30 second delay.
 wingbits feeder start 2>&1 | stdbuf -o0 sed --unbuffered '/^$/d' |  awk -W interactive '{print "[wingbits-feeder]     " $0}' &
 sleep 30
-/usr/bin/feed-wingbits --net --net-only --debug=n --quiet --net-connector localhost,30006,json_out --net-connector localhost,30015,beast_reduce_out --write-json /run/wingbits-feed --net-beast-reduce-interval 0.125 --net-beast-reduce-optimize-for-mlat --net-heartbeat 60 --net-ro-size 1280 --net-ro-interval 0.2 --net-ro-port 0 --net-sbs-port 0 --net-bi-port 30154 --net-bo-port 0 --net-ri-port 0 "${WINGBITS_NET_CONNECTOR[@]}" 2>&1 | stdbuf -o0 sed --unbuffered '/^$/d' |  awk -W interactive '{print "[readsb-wingbits]     " $0}' &
+/usr/bin/feed-wingbits --net --net-only --debug=n --quiet --net-connector localhost,30015,beast_reduce_out --write-json /run/wingbits-feed --net-beast-reduce-interval 0.125 --net-beast-reduce-optimize-for-mlat --net-heartbeat 60 --net-ro-size 1280 --net-ro-interval 0.2 --net-ro-port 0 --net-sbs-port 0 --net-bi-port 30154 --net-bo-port 0 --net-ri-port 0 "${WINGBITS_NET_CONNECTOR[@]}" 2>&1 | stdbuf -o0 sed --unbuffered '/^$/d' |  awk -W interactive '{print "[readsb-wingbits]     " $0}' &
 
 # Wait for any services to exit.
 wait -n


### PR DESCRIPTION
The JSON server at Wingbits is now offline.  Everyone who uses Wingbits will (or has) started to receive log spam similar to:

`Position json output: Connection to localhost (::1) port 30006 failed: Transport endpoint is not connected`

This removes the json_out net connector parameter so we explicitly use BEAST moving forward.