### PR TITLE
build(autohupr): switch to alpine:3.23 + apk nodejs/npm to keep armv7hf support

### DIFF
--- a/autohupr/Dockerfile.template
+++ b/autohupr/Dockerfile.template
@@ -2,9 +2,6 @@ ARG ALPINE_VERSION=3.23
 FROM alpine:${ALPINE_VERSION}
 LABEL maintainer="https://github.com/ketilmo"
 
-# Re-declare inside the build stage so it's visible to RUN.
-ARG ALPINE_VERSION
-
 # renovate: alpine-package=nodejs
 ARG NODEJS_VERSION=24
 

--- a/autohupr/Dockerfile.template
+++ b/autohupr/Dockerfile.template
@@ -1,7 +1,19 @@
-FROM node:22-alpine3.23
+ARG ALPINE_VERSION=3.23
+FROM alpine:${ALPINE_VERSION}
 LABEL maintainer="https://github.com/ketilmo"
 
+# Re-declare inside the build stage so it's visible to RUN.
+ARG ALPINE_VERSION
+
+# renovate: alpine-package=nodejs
+ARG NODEJS_VERSION=24
+
+# renovate: alpine-package=npm
+ARG NPM_VERSION=11
+
 RUN apk add --no-cache \
+    "nodejs=~${NODEJS_VERSION}" \
+    "npm=~${NPM_VERSION}" \
     bash \
     tini \
     curl

--- a/renovate.json
+++ b/renovate.json
@@ -99,6 +99,36 @@
       "currentValueTemplate": "dev",
       "packageNameTemplate": "https://github.com/flightaware/piaware_builder",
       "datasourceTemplate": "git-refs"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)autohupr/Dockerfile\\.template$/"
+      ],
+      "matchStringsStrategy": "combination",
+      "matchStrings": [
+        "ARG ALPINE_VERSION=(?<alpineVer>\\S+)",
+        "# renovate: alpine-package=nodejs\\s+ARG NODEJS_VERSION=(?<currentValue>\\d+)"
+      ],
+      "depNameTemplate": "alpine_{{replace \"\\.\" \"_\" alpineVer}}/nodejs",
+      "datasourceTemplate": "repology",
+      "versioningTemplate": "loose",
+      "extractVersionTemplate": "^(?<version>\\d+)"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)autohupr/Dockerfile\\.template$/"
+      ],
+      "matchStringsStrategy": "combination",
+      "matchStrings": [
+        "ARG ALPINE_VERSION=(?<alpineVer>\\S+)",
+        "# renovate: alpine-package=npm\\s+ARG NPM_VERSION=(?<currentValue>\\d+)"
+      ],
+      "depNameTemplate": "alpine_{{replace \"\\.\" \"_\" alpineVer}}/npm",
+      "datasourceTemplate": "repology",
+      "versioningTemplate": "loose",
+      "extractVersionTemplate": "^(?<version>\\d+)"
     }
   ],
   "customDatasources": {


### PR DESCRIPTION
## Summary

The `autohupr` container fails to build on **armv7hf** when the base bumps to `node:24-alpine3.23`, because the official `node` Docker library [dropped the `arm32v7` variant](https://hub.docker.com/_/node) for the `24-alpine3.23` tag. This switches the base image to plain `alpine:3.23` (which still ships armv7hf) and installs `nodejs` and `npm` via `apk` with fuzzy major-version pins, keeping us roughly on Node 24 / npm 11 while picking up Alpine patch updates automatically.

## Design — single source of truth for Alpine version

`ARG ALPINE_VERSION=3.23` declared before `FROM` is the **only** place the Alpine version lives. Two new `matchStringsStrategy=combination` custom managers in `renovate.json` compose the Repology depName (`alpine_3_23/nodejs`, `alpine_3_23/npm`) at lookup time from `ALPINE_VERSION`, so bumping Alpine is a single-line Dockerfile edit and Renovate auto-retargets the inner-dep watchers to the new Alpine branch with no `renovate.json` changes required.

## Renovate watchers after this PR

1. **Alpine base image itself** — built-in `dockerfile` manager (unchanged).
2. **Major bumps of nodejs** in the currently-pinned Alpine branch (e.g. when Alpine ships nodejs 26).
3. **Major bumps of npm** in the currently-pinned Alpine branch (e.g. when Alpine ships npm 12+).

## Verification

- `renovate --platform=local --dry-run=lookup` confirms both new managers extract `alpine_3_23/nodejs=24` and `alpine_3_23/npm=11` with no updates proposed (Alpine 3.23 currently ships nodejs 24.14.1 and npm 11.11.0).
- Multi-arch draft fleet build via [schubydoo/balena-ads-b#11](https://github.com/schubydoo/balena-ads-b/pull/11) — **all three architectures green**:
  - `aarch64` — pass (2m7s)
  - `amd64`   — pass (1m53s)
  - `armv7hf` — pass (2m19s)

## Test plan

- [x] Renovate config validates and dry-run lookup produces expected deps with no spurious updates
- [x] Image builds on aarch64
- [x] Image builds on amd64
- [x] Image builds on armv7hf
- [x] Smoke-test on a real device: `autohupr` container starts, `node --version` reports `v24.x`, `npm --version` reports `11.x`

Opened as **draft** for upstream review; @schubydoo will flip to ready when satisfied.