### PR TITLE
ci(opensky-version): retry Package download for up to 6 hours

### DIFF
--- a/.github/workflows/opensky-version.yml
+++ b/.github/workflows/opensky-version.yml
@@ -16,21 +16,18 @@ jobs:
           ref: 'master'
 
       - name: Download Package File
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
-        with:
-          timeout_minutes: 2
-          max_attempts: 5
-          retry_wait_seconds: 30
-          command: |
-            aria2c \
-              --connect-timeout=20 \
-              --timeout=30 \
-              --max-tries=3 \
-              --retry-wait=10 \
-              --lowest-speed-limit=1K \
-              -x 2 \
-              -o opensky-network/.Packages \
-              https://s3.opensky-network.org/website-public-repos/debian/dists/opensky/custom/binary-arm64/Packages
+        timeout-minutes: 360
+        shell: bash
+        run: |
+          aria2c \
+            --connect-timeout=30 \
+            --timeout=120 \
+            --max-tries=72 \
+            --retry-wait=180 \
+            --lowest-speed-limit=1K \
+            -x 2 \
+            -o opensky-network/.Packages \
+            https://s3.opensky-network.org/website-public-repos/debian/dists/opensky/custom/binary-arm64/Packages
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1


### PR DESCRIPTION
retry Package download for up to 6 hours