### PR TITLE
fix(deploy-to-balena-draft): replace wretry.action with manual retries

### DIFF
--- a/.github/workflows/deploy-to-balena-draft.yml
+++ b/.github/workflows/deploy-to-balena-draft.yml
@@ -23,12 +23,49 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
-      - name: Build on Balena with ${{ matrix.architecture }} architecture
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+      - name: Build on Balena with ${{ matrix.architecture }} architecture (attempt 1)
+        id: build1
+        continue-on-error: true
+        uses: balena-io/deploy-to-balena-action@638e3085dfe40b8c3cef2a34fe9d0874e572de4e # v2.2.0
         with:
-          action: balena-io/deploy-to-balena-action@638e3085dfe40b8c3cef2a34fe9d0874e572de4e # v2.2.0
-          with: |
-            balena_token: ${{ secrets.BALENA_DRAFT_API_KEY }}
-            fleet: ${{ vars.BALENA_DRAFT_FLEET }}-${{ matrix.architecture }}
-            multi_dockerignore: true
-          attempt_limit: 5
+          balena_token: ${{ secrets.BALENA_DRAFT_API_KEY }}
+          fleet: ${{ vars.BALENA_DRAFT_FLEET }}-${{ matrix.architecture }}
+          multi_dockerignore: true
+
+      - name: Build on Balena with ${{ matrix.architecture }} architecture (attempt 2)
+        id: build2
+        if: steps.build1.outcome == 'failure'
+        continue-on-error: true
+        uses: balena-io/deploy-to-balena-action@638e3085dfe40b8c3cef2a34fe9d0874e572de4e # v2.2.0
+        with:
+          balena_token: ${{ secrets.BALENA_DRAFT_API_KEY }}
+          fleet: ${{ vars.BALENA_DRAFT_FLEET }}-${{ matrix.architecture }}
+          multi_dockerignore: true
+
+      - name: Build on Balena with ${{ matrix.architecture }} architecture (attempt 3)
+        id: build3
+        if: steps.build1.outcome == 'failure' && steps.build2.outcome == 'failure'
+        continue-on-error: true
+        uses: balena-io/deploy-to-balena-action@638e3085dfe40b8c3cef2a34fe9d0874e572de4e # v2.2.0
+        with:
+          balena_token: ${{ secrets.BALENA_DRAFT_API_KEY }}
+          fleet: ${{ vars.BALENA_DRAFT_FLEET }}-${{ matrix.architecture }}
+          multi_dockerignore: true
+
+      - name: Build on Balena with ${{ matrix.architecture }} architecture (attempt 4)
+        id: build4
+        if: steps.build1.outcome == 'failure' && steps.build2.outcome == 'failure' && steps.build3.outcome == 'failure'
+        continue-on-error: true
+        uses: balena-io/deploy-to-balena-action@638e3085dfe40b8c3cef2a34fe9d0874e572de4e # v2.2.0
+        with:
+          balena_token: ${{ secrets.BALENA_DRAFT_API_KEY }}
+          fleet: ${{ vars.BALENA_DRAFT_FLEET }}-${{ matrix.architecture }}
+          multi_dockerignore: true
+
+      - name: Build on Balena with ${{ matrix.architecture }} architecture (attempt 5)
+        if: steps.build1.outcome == 'failure' && steps.build2.outcome == 'failure' && steps.build3.outcome == 'failure' && steps.build4.outcome == 'failure'
+        uses: balena-io/deploy-to-balena-action@638e3085dfe40b8c3cef2a34fe9d0874e572de4e # v2.2.0
+        with:
+          balena_token: ${{ secrets.BALENA_DRAFT_API_KEY }}
+          fleet: ${{ vars.BALENA_DRAFT_FLEET }}-${{ matrix.architecture }}
+          multi_dockerignore: true


### PR DESCRIPTION
## Summary

- `Wandalen/wretry.action` (added in #516) is silently breaking every PR check with `BALENA_TOKEN input cannot be empty`. Reverts the retry mechanism to manual step duplication using `continue-on-error` + `if: steps.X.outcome == 'failure'`.
- Behavior preserved: up to 5 attempts before the job fails.
- No new third-party dependencies; the only wrapped action remains `balena-io/deploy-to-balena-action` (already pinned).

## Why wretry.action doesn't work here

`balena-io/deploy-to-balena-action`'s `action.yml` defines:

```yaml
runs:
  using: docker
  image: docker://ghcr.io/balena-io/deploy-to-balena-action:v2.2.0
  env:
    BALENA_TOKEN: ${{ inputs.balena_token }}
    BALENA_URL: ${{ inputs.environment }}
```

When GitHub Actions runs this natively, it processes the `runs.env` block and adds `-e BALENA_TOKEN=<value>` to the `docker run` command. `Wandalen/wretry.action` doesn't reimplement that semantic — it only sets `INPUT_BALENA_TOKEN`. The action's container code reads `BALENA_TOKEN`, finds it empty, and exits 1 in ~250ms. All 5 retry attempts fail identically and immediately. Example failed run: https://github.com/ketilmo/balena-ads-b/actions/runs/25699372982 (PR #517).

This is a known gap in `wretry.action` (see issues [#137](https://github.com/Wandalen/wretry.action/issues/137), [#188](https://github.com/Wandalen/wretry.action/issues/188)) — it doesn't fully reimplement Docker action semantics from `action.yml`.

## Test plan

- [ ] Open or push to a PR after this lands; verify all three matrix jobs (`aarch64`, `amd64`, `armv7hf`) run the build container past startup (not failing in ~250ms with `BALENA_TOKEN input cannot be empty`).
- [ ] If transient Balena failures occur, verify subsequent attempt steps show up and run.