### PR TITLE
Add Supervisor update support and improve OpenSky download retries

### DIFF
--- a/.github/workflows/opensky-version.yml
+++ b/.github/workflows/opensky-version.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   update-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 360
     permissions:
       contents: write
       pull-requests: write
@@ -21,22 +22,59 @@ jobs:
         with:
           ref: 'master'
 
-      - name: Download Package Files
-        timeout-minutes: 360
-        shell: bash
-        run: |
-          for arch in arm64 amd64 armhf; do
+      - name: Download arm64 Package File
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_seconds: 60
+          max_attempts: 24
+          retry_wait_seconds: 180
+          shell: bash
+          command: |
             aria2c \
               --connect-timeout=30 \
-              --timeout=120 \
-              --max-tries=24 \
-              --retry-wait=180 \
-              --lowest-speed-limit=1K \
+              --timeout=30 \
+              --lowest-speed-limit=10K \
+              --max-tries=1 \
               -x 2 \
               --allow-overwrite=true \
-              -o "opensky-network/.Packages.${arch}" \
-              "https://s3.opensky-network.org/website-public-repos/debian/dists/opensky/custom/binary-${arch}/Packages"
-          done
+              -o opensky-network/.Packages.arm64 \
+              https://s3.opensky-network.org/website-public-repos/debian/dists/opensky/custom/binary-arm64/Packages
+
+      - name: Download amd64 Package File
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_seconds: 60
+          max_attempts: 24
+          retry_wait_seconds: 180
+          shell: bash
+          command: |
+            aria2c \
+              --connect-timeout=30 \
+              --timeout=30 \
+              --lowest-speed-limit=10K \
+              --max-tries=1 \
+              -x 2 \
+              --allow-overwrite=true \
+              -o opensky-network/.Packages.amd64 \
+              https://s3.opensky-network.org/website-public-repos/debian/dists/opensky/custom/binary-amd64/Packages
+
+      - name: Download armhf Package File
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_seconds: 60
+          max_attempts: 24
+          retry_wait_seconds: 180
+          shell: bash
+          command: |
+            aria2c \
+              --connect-timeout=30 \
+              --timeout=30 \
+              --lowest-speed-limit=10K \
+              --max-tries=1 \
+              -x 2 \
+              --allow-overwrite=true \
+              -o opensky-network/.Packages.armhf \
+              https://s3.opensky-network.org/website-public-repos/debian/dists/opensky/custom/binary-armhf/Packages
 
       - name: Sync OPENSKY_VERSION in Dockerfile
         shell: bash

--- a/.github/workflows/opensky-version.yml
+++ b/.github/workflows/opensky-version.yml
@@ -35,7 +35,6 @@ jobs:
               --timeout=30 \
               --lowest-speed-limit=10K \
               --max-tries=1 \
-              -x 2 \
               --allow-overwrite=true \
               -o opensky-network/.Packages.arm64 \
               https://s3.opensky-network.org/website-public-repos/debian/dists/opensky/custom/binary-arm64/Packages
@@ -53,7 +52,6 @@ jobs:
               --timeout=30 \
               --lowest-speed-limit=10K \
               --max-tries=1 \
-              -x 2 \
               --allow-overwrite=true \
               -o opensky-network/.Packages.amd64 \
               https://s3.opensky-network.org/website-public-repos/debian/dists/opensky/custom/binary-amd64/Packages
@@ -71,7 +69,6 @@ jobs:
               --timeout=30 \
               --lowest-speed-limit=10K \
               --max-tries=1 \
-              -x 2 \
               --allow-overwrite=true \
               -o opensky-network/.Packages.armhf \
               https://s3.opensky-network.org/website-public-repos/debian/dists/opensky/custom/binary-armhf/Packages

--- a/README.md
+++ b/README.md
@@ -559,8 +559,8 @@ Automatically keep your balenaOS host release and/or the balena Supervisor up-to
 
 ### Supervisor updates
 
-- `SUPERVISOR_CHECK_INTERVAL`: Interval between checking for available Supervisor updates. Default is `1d`.
-- `SUPERVISOR_TARGET_VERSION`: The Supervisor version you want the device pinned to. This variable must be set for a Supervisor update to be performed. Set it to `latest`/`recommended` to always pull the newest available Supervisor for the device's CPU architecture, or to a specific version substring (e.g. `16.8.2` or `16.8`). Do **not** include a leading `v`. Once a new target is set the on-device Supervisor updater applies it on its next poll — 15 minutes after boot, then every 24 hours thereafter — so the actual upgrade may take up to a day to land unless the device is rebooted.
+- `SUPERVISOR_CHECK_INTERVAL`: Interval between checking for available Supervisor updates. Default is `1d`. Must include a unit (`s`/`m`/`h`/`d`); minimum `1s`, maximum `24d`.
+- `SUPERVISOR_TARGET_VERSION`: The Supervisor version you want the device pinned to. This variable must be set for a Supervisor update to be performed. Set it to `latest`/`recommended` to always pull the newest available Supervisor for the device's CPU architecture, to a full version like `16.8.2` for an exact pin, or to a partial version like `16.8` to track the newest release in that line. Matching is segment-aware, so `16.8` matches `16.8.x` but not `16.80.x`. Do **not** include a leading `v`. Once a new target is set the on-device Supervisor updater applies it on its next poll — 15 minutes after boot, then every 24 hours thereafter — so the actual upgrade may take up to a day to land unless the device is rebooted.
 
 ## Custom MLAT client
 

--- a/README.md
+++ b/README.md
@@ -548,12 +548,19 @@ By default, dump1090 will run with adaptive gain in dynamic range mode. You can 
 ## Device reboot on service exit
 dump978 and dump1090 can restart the device if it hits an error. You can enable this feature by setting a *Device Variable* named `REBOOT_DEVICE_ON_SERVICE_EXIT` with the value of `true`.
 
-## Automatic balenaOS host updates
+## Automatic balenaOS host and Supervisor updates
 
-Automatically keep your balenaOS host release up-to-date. To enable this service, create a *Device Variables* named `ENABLED_SERVICES` with the value of `autohupr`. You may also want to set the following *Device Variables*:
+Automatically keep your balenaOS host release and/or the balena Supervisor up-to-date. To enable this service, create a *Device Variable* named `ENABLED_SERVICES` with the value of `autohupr`. The two updaters are independent: set the target-version variable for whichever you want to keep up-to-date and leave the other unset.
 
-- `HUP_CHECK_INTERVAL`: Interval between checking for available updates. Default is 1d.
-- `HUP_TARGET_VERSION`: The OS version you want balenaHUP to automatically update your device to. This is a required variable to be specified, otherwise, an update won't be performed by default. Set the variable to 'latest'/'recommended' for your device to always update to the latest OS version or set it to a specific version (e.g '2.107.10').
+### Host OS updates
+
+- `HUP_CHECK_INTERVAL`: Interval between checking for available host OS updates. Default is `1d`.
+- `HUP_TARGET_VERSION`: The OS version you want balenaHUP to automatically update your device to. This variable must be set for an OS update to be performed. Set it to `latest`/`recommended` to always pull the latest OS version, or to a specific version (e.g. `2.107.10`).
+
+### Supervisor updates
+
+- `SUPERVISOR_CHECK_INTERVAL`: Interval between checking for available Supervisor updates. Default is `1d`.
+- `SUPERVISOR_TARGET_VERSION`: The Supervisor version you want the device pinned to. This variable must be set for a Supervisor update to be performed. Set it to `latest`/`recommended` to always pull the newest available Supervisor for the device's CPU architecture, or to a specific version substring (e.g. `16.8.2` or `16.8`). Do **not** include a leading `v`. Once a new target is set the on-device Supervisor updater applies it on its next poll — 15 minutes after boot, then every 24 hours thereafter — so the actual upgrade may take up to a day to land unless the device is rebooted.
 
 ## Custom MLAT client
 

--- a/autohupr/Dockerfile.template
+++ b/autohupr/Dockerfile.template
@@ -31,7 +31,7 @@ RUN apk add --no-cache --virtual .git-deps git && \
 RUN npm ci && npm run build && npm prune --omit=dev && \
     npm cache clean --force && rm -rf /tmp/*
 
-COPY start.sh ./
+COPY start.sh supervisor-update.cjs ./
 
 RUN chmod +x ./start.sh
 

--- a/autohupr/start.sh
+++ b/autohupr/start.sh
@@ -7,7 +7,10 @@ if [[ ",$(echo -e "${ENABLED_SERVICES}" | tr -d '[:space:]')," != *",$BALENA_SER
         echo "$BALENA_SERVICE_NAME is not enabled. Sending request to stop the service:"
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
         echo " "
-        tail -f /dev/null
+        # Replace this shell with tail so a docker stop / SIGTERM terminates
+        # the container directly instead of letting bash fall through into the
+        # updater section below once tail exits.
+        exec tail -f /dev/null
 fi
 
 # Run the upstream host-OS updater (build/main.js) and our Supervisor updater

--- a/autohupr/start.sh
+++ b/autohupr/start.sh
@@ -10,5 +10,20 @@ if [[ ",$(echo -e "${ENABLED_SERVICES}" | tr -d '[:space:]')," != *",$BALENA_SER
         tail -f /dev/null
 fi
 
-# Start app
-node ./build/main.js
+# Run the upstream host-OS updater (build/main.js) and our Supervisor updater
+# (supervisor-update.cjs) in parallel. If either exits, terminate the other so
+# the container exits cleanly and the compose restart policy respawns it.
+set +e
+
+node ./build/main.js &
+PID_HUP=$!
+node ./supervisor-update.cjs &
+PID_SUP=$!
+
+trap 'kill -TERM "$PID_HUP" "$PID_SUP" 2>/dev/null; wait; exit 0' SIGTERM SIGINT
+
+wait -n
+EXIT_CODE=$?
+kill -TERM "$PID_HUP" "$PID_SUP" 2>/dev/null
+wait
+exit "$EXIT_CODE"

--- a/autohupr/supervisor-update.cjs
+++ b/autohupr/supervisor-update.cjs
@@ -13,7 +13,7 @@
 //                               '16.8.x' but not '16.80.x'). Do NOT prefix
 //                               with 'v' — balena-sdk's raw_version has none.
 //   SUPERVISOR_CHECK_INTERVAL   default '1d'. Must include a unit (s/m/h/d);
-//                               minimum 1s, maximum ~24.8d.
+//                               minimum 1s, maximum 24d.
 
 'use strict';
 
@@ -49,13 +49,14 @@ const parseDurationMs = (v) => {
 	const unit = m[2].toLowerCase();
 	const ms = n * { s: 1e3, m: 6e4, h: 36e5, d: 864e5 }[unit];
 	// setTimeout silently clamps to 1ms when the delay > 2^31-1, which would
-	// turn the loop into a busy poller. Reject anything below 1s or above the
-	// ~24.8d setTimeout ceiling.
+	// turn the loop into a busy poller. Reject anything below 1s, and cap the
+	// max at exactly 24d so the documented limit and the enforced limit agree
+	// (24d = 2_073_600_000 ms is safely within the setTimeout 32-bit window).
 	if (ms < 1000) {
 		throw new Error(`duration '${v}' is below the 1s minimum`);
 	}
-	if (ms > 2_147_483_647) {
-		throw new Error(`duration '${v}' exceeds the ~24.8d maximum`);
+	if (ms > 24 * 86_400_000) {
+		throw new Error(`duration '${v}' exceeds the 24d maximum`);
 	}
 	return ms;
 };

--- a/autohupr/supervisor-update.cjs
+++ b/autohupr/supervisor-update.cjs
@@ -39,13 +39,13 @@ for (const [name, value] of [
 }
 
 const parseDurationMs = (v) => {
-	const m = String(v).trim().match(/^(\d+(?:\.\d+)?)\s*(ms|s|m|h|d)$/i);
+	const m = String(v).trim().match(/^(\d+(?:\.\d+)?)\s*(s|m|h|d)$/i);
 	if (!m) {
 		throw new Error(`expected a number with unit (e.g. '30s', '5m', '1h', '1d'), got '${v}'`);
 	}
 	const n = Number(m[1]);
 	const unit = m[2].toLowerCase();
-	const ms = n * { ms: 1, s: 1e3, m: 6e4, h: 36e5, d: 864e5 }[unit];
+	const ms = n * { s: 1e3, m: 6e4, h: 36e5, d: 864e5 }[unit];
 	// setTimeout silently clamps to 1ms when the delay > 2^31-1, which would
 	// turn the loop into a busy poller. Reject anything below 1s or above the
 	// ~24.8d setTimeout ceiling.
@@ -173,15 +173,39 @@ const tick = async () => {
 	log('Target set. On-device updater applies it on next poll (15min after boot, then every 24h).');
 };
 
+const ERROR_BACKOFF_START_MS = 30_000;
+
+const formatMs = (ms) => {
+	if (ms >= 86_400_000 && ms % 86_400_000 === 0) return `${ms / 86_400_000}d`;
+	if (ms >= 3_600_000 && ms % 3_600_000 === 0) return `${ms / 3_600_000}h`;
+	if (ms >= 60_000 && ms % 60_000 === 0) return `${ms / 60_000}m`;
+	return `${Math.round(ms / 1000)}s`;
+};
+
 const main = async () => {
+	// On error we back off exponentially starting at 30s, doubling each
+	// consecutive failure and capped at the configured check interval. On any
+	// successful tick we reset to the configured cadence. This keeps transient
+	// API or network blips from skipping a full SUPERVISOR_CHECK_INTERVAL.
+	let errorBackoffMs = ERROR_BACKOFF_START_MS;
 	while (true) {
+		let failed = false;
 		try {
 			await tick();
 		} catch (e) {
 			err('Error in loop:', e?.message || e);
+			failed = true;
 		}
-		log(`Will check again in ${checkIntervalDisplay}.`);
-		await delay(checkIntervalMs);
+		if (failed) {
+			const sleepMs = Math.min(errorBackoffMs, checkIntervalMs);
+			log(`Will retry in ${formatMs(sleepMs)} after error.`);
+			await delay(sleepMs);
+			errorBackoffMs = Math.min(errorBackoffMs * 2, checkIntervalMs);
+		} else {
+			errorBackoffMs = ERROR_BACKOFF_START_MS;
+			log(`Will check again in ${checkIntervalDisplay}.`);
+			await delay(checkIntervalMs);
+		}
 	}
 };
 

--- a/autohupr/supervisor-update.cjs
+++ b/autohupr/supervisor-update.cjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// Sidecar to autohupr-example's host-OS updater: keeps the balena Supervisor
+// pinned to SUPERVISOR_TARGET_VERSION via the balenaCloud API. Runs alongside
+// build/main.js (the upstream HUP loop) — see start.sh.
+//
+// Auto-injected env (io.balena.features.balena-api):
+//   BALENA_API_KEY, BALENA_API_URL, BALENA_DEVICE_UUID
+//
+// User config:
+//   SUPERVISOR_TARGET_VERSION   '' (disabled) | 'latest' | 'recommended' |
+//                               version substring, e.g. '16.8.2' or '16.8'.
+//                               Do NOT prefix with 'v' — balena-sdk's
+//                               raw_version field has no leading 'v'.
+//   SUPERVISOR_CHECK_INTERVAL   default '1d'. Supports s/m/h/d suffixes.
+
+'use strict';
+
+const { getSdk } = require('balena-sdk');
+
+const LOG_PREFIX = '[supervisor-update]';
+const log = (...a) => console.log(LOG_PREFIX, ...a);
+const err = (...a) => console.error(LOG_PREFIX, ...a);
+
+const apiKey = process.env.BALENA_API_KEY;
+const apiUrl = process.env.BALENA_API_URL;
+const deviceUuid = process.env.BALENA_DEVICE_UUID;
+const userTargetVersion = (process.env.SUPERVISOR_TARGET_VERSION || '').trim();
+const checkIntervalRaw = process.env.SUPERVISOR_CHECK_INTERVAL || '1d';
+
+for (const [name, value] of [
+	['BALENA_API_KEY', apiKey],
+	['BALENA_API_URL', apiUrl],
+	['BALENA_DEVICE_UUID', deviceUuid],
+]) {
+	if (!value) {
+		err(`${name} required in environment`);
+		process.exit(1);
+	}
+}
+
+const parseDurationMs = (v) => {
+	const m = String(v).trim().match(/^(\d+(?:\.\d+)?)\s*(ms|s|m|h|d)?$/i);
+	if (!m) {
+		throw new Error(`Cannot parse duration: ${v}`);
+	}
+	const n = Number(m[1]);
+	const unit = (m[2] || 'ms').toLowerCase();
+	return n * { ms: 1, s: 1e3, m: 6e4, h: 36e5, d: 864e5 }[unit];
+};
+
+let checkIntervalMs;
+try {
+	checkIntervalMs = parseDurationMs(checkIntervalRaw);
+} catch (e) {
+	err(`Invalid SUPERVISOR_CHECK_INTERVAL='${checkIntervalRaw}'; falling back to 1d.`);
+	checkIntervalMs = 86_400_000;
+}
+
+const balena = getSdk({ apiUrl, dataDirectory: '/tmp/work' });
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const stripV = (s) => String(s || '').replace(/^v/i, '');
+
+const getCpuArch = async (uuid) => {
+	const device = await balena.models.device.get(uuid, {
+		$expand: { is_of__device_type: { $select: 'slug' } },
+	});
+	const dtSlug = Array.isArray(device.is_of__device_type)
+		? device.is_of__device_type[0]?.slug
+		: undefined;
+	if (!dtSlug) {
+		throw new Error(`Could not resolve device-type slug for ${uuid}`);
+	}
+	const dt = await balena.models.deviceType.getBySlugOrName(dtSlug, {
+		$select: 'slug',
+		$expand: { is_of__cpu_architecture: { $select: 'slug' } },
+	});
+	const arch = Array.isArray(dt.is_of__cpu_architecture)
+		? dt.is_of__cpu_architecture[0]?.slug
+		: undefined;
+	if (!arch) {
+		throw new Error(`Could not resolve CPU architecture for device-type ${dtSlug}`);
+	}
+	return { dtSlug, arch };
+};
+
+const getCurrentSupervisorVersion = async (uuid) => {
+	const device = await balena.models.device.get(uuid, {
+		$select: ['supervisor_version'],
+	});
+	return stripV(device.supervisor_version || '');
+};
+
+const resolveTargetVersion = async (arch) => {
+	const releases = await balena.models.os.getSupervisorReleasesForCpuArchitecture(
+		arch,
+		{ $select: ['id', 'raw_version'] },
+	);
+	if (!releases.length) {
+		return null;
+	}
+	if (['latest', 'recommended'].includes(userTargetVersion.toLowerCase())) {
+		return stripV(releases[0].raw_version);
+	}
+	const wanted = stripV(userTargetVersion);
+	const match = releases.find((r) => stripV(r.raw_version).includes(wanted));
+	return match ? stripV(match.raw_version) : null;
+};
+
+// SDK 20.x exposes setSupervisorRelease; SDK 23+ renamed it to
+// pinToSupervisorRelease and dropped the old name. Pick whichever exists so a
+// future balena-sdk bump doesn't silently break.
+const pinSupervisor = async (uuid, version) => {
+	const fn =
+		balena.models.device.pinToSupervisorRelease ||
+		balena.models.device.setSupervisorRelease;
+	if (typeof fn !== 'function') {
+		throw new Error('balena-sdk has neither pinToSupervisorRelease nor setSupervisorRelease');
+	}
+	return fn.call(balena.models.device, uuid, version);
+};
+
+const tick = async () => {
+	if (userTargetVersion === '') {
+		log("SUPERVISOR_TARGET_VERSION not set; skipping. (Set to 'latest' or e.g. '16.8.2' to enable.)");
+		return;
+	}
+
+	await balena.auth.loginWithToken(apiKey);
+
+	while (!(await balena.models.device.isOnline(deviceUuid))) {
+		log('Device is offline...');
+		await delay(120_000);
+	}
+
+	const { dtSlug, arch } = await getCpuArch(deviceUuid);
+	const currentVersion = await getCurrentSupervisorVersion(deviceUuid);
+	log(`Current supervisor: ${currentVersion || '(unknown)'} (device type ${dtSlug}, arch ${arch})`);
+
+	const targetVersion = await resolveTargetVersion(arch);
+	if (!targetVersion) {
+		log(`No supervisor release matching '${userTargetVersion}' found for ${arch}.`);
+		return;
+	}
+
+	if (currentVersion === targetVersion) {
+		log(`Already on target supervisor ${targetVersion}.`);
+		return;
+	}
+
+	log(`Setting target supervisor release ${targetVersion} (current ${currentVersion || 'unknown'})...`);
+	await pinSupervisor(deviceUuid, targetVersion);
+	log('Target set. On-device updater applies it on next poll (15min after boot, then every 24h).');
+};
+
+const main = async () => {
+	while (true) {
+		try {
+			await tick();
+		} catch (e) {
+			err('Error in loop:', e?.message || e);
+		}
+		log(`Will check again in ${checkIntervalRaw}.`);
+		await delay(checkIntervalMs);
+	}
+};
+
+log('Starting up...');
+main().catch((e) => {
+	err('Fatal:', e);
+	process.exit(1);
+});

--- a/autohupr/supervisor-update.cjs
+++ b/autohupr/supervisor-update.cjs
@@ -146,6 +146,15 @@ const pinSupervisor = async (uuid, version) => {
 	return fn.call(balena.models.device, uuid, version);
 };
 
+// Tracks the version we most recently asked the API to pin (within this
+// process). The on-device Supervisor updater polls only every 15min/24h, so
+// the running supervisor_version stays unchanged for a while after a pin; if
+// we re-called pinSupervisor every tick during that window we'd hammer the
+// balenaCloud API with redundant idempotent writes. Reset to null after the
+// pin actually lands (currentVersion === targetVersion) so a later user
+// change of SUPERVISOR_TARGET_VERSION still triggers a fresh pin.
+let lastPinnedVersion = null;
+
 const tick = async () => {
 	if (userTargetVersion === '') {
 		log("SUPERVISOR_TARGET_VERSION not set; skipping. (Set to 'latest' or e.g. '16.8.2' to enable.)");
@@ -170,12 +179,19 @@ const tick = async () => {
 	}
 
 	if (currentVersion === targetVersion) {
+		lastPinnedVersion = null;
 		log(`Already on target supervisor ${targetVersion}.`);
+		return;
+	}
+
+	if (lastPinnedVersion === targetVersion) {
+		log(`Target ${targetVersion} already pinned this run; waiting for the on-device updater to apply it.`);
 		return;
 	}
 
 	log(`Setting target supervisor release ${targetVersion} (current ${currentVersion || 'unknown'})...`);
 	await pinSupervisor(deviceUuid, targetVersion);
+	lastPinnedVersion = targetVersion;
 	log('Target set. On-device updater applies it on next poll (15min after boot, then every 24h).');
 };
 

--- a/autohupr/supervisor-update.cjs
+++ b/autohupr/supervisor-update.cjs
@@ -39,21 +39,35 @@ for (const [name, value] of [
 }
 
 const parseDurationMs = (v) => {
-	const m = String(v).trim().match(/^(\d+(?:\.\d+)?)\s*(ms|s|m|h|d)?$/i);
+	const m = String(v).trim().match(/^(\d+(?:\.\d+)?)\s*(ms|s|m|h|d)$/i);
 	if (!m) {
-		throw new Error(`Cannot parse duration: ${v}`);
+		throw new Error(`expected a number with unit (e.g. '30s', '5m', '1h', '1d'), got '${v}'`);
 	}
 	const n = Number(m[1]);
-	const unit = (m[2] || 'ms').toLowerCase();
-	return n * { ms: 1, s: 1e3, m: 6e4, h: 36e5, d: 864e5 }[unit];
+	const unit = m[2].toLowerCase();
+	const ms = n * { ms: 1, s: 1e3, m: 6e4, h: 36e5, d: 864e5 }[unit];
+	// setTimeout silently clamps to 1ms when the delay > 2^31-1, which would
+	// turn the loop into a busy poller. Reject anything below 1s or above the
+	// ~24.8d setTimeout ceiling.
+	if (ms < 1000) {
+		throw new Error(`duration '${v}' is below the 1s minimum`);
+	}
+	if (ms > 2_147_483_647) {
+		throw new Error(`duration '${v}' exceeds the ~24.8d maximum`);
+	}
+	return ms;
 };
 
+const DEFAULT_INTERVAL = '1d';
 let checkIntervalMs;
+let checkIntervalDisplay;
 try {
 	checkIntervalMs = parseDurationMs(checkIntervalRaw);
+	checkIntervalDisplay = checkIntervalRaw;
 } catch (e) {
-	err(`Invalid SUPERVISOR_CHECK_INTERVAL='${checkIntervalRaw}'; falling back to 1d.`);
-	checkIntervalMs = 86_400_000;
+	err(`Invalid SUPERVISOR_CHECK_INTERVAL='${checkIntervalRaw}': ${e.message}. Falling back to ${DEFAULT_INTERVAL}.`);
+	checkIntervalMs = parseDurationMs(DEFAULT_INTERVAL);
+	checkIntervalDisplay = DEFAULT_INTERVAL;
 }
 
 const balena = getSdk({ apiUrl, dataDirectory: '/tmp/work' });
@@ -92,6 +106,11 @@ const getCurrentSupervisorVersion = async (uuid) => {
 	return stripV(device.supervisor_version || '');
 };
 
+// Segment-aware match: '16.8.2' matches only the exact '16.8.2' (not
+// '16.8.20'), and '16.8' matches '16.8.x' (not '16.80.x' or '16.81.x').
+const matchesTargetVersion = (raw, wanted) =>
+	raw === wanted || raw.startsWith(wanted + '.');
+
 const resolveTargetVersion = async (arch) => {
 	const releases = await balena.models.os.getSupervisorReleasesForCpuArchitecture(
 		arch,
@@ -104,7 +123,7 @@ const resolveTargetVersion = async (arch) => {
 		return stripV(releases[0].raw_version);
 	}
 	const wanted = stripV(userTargetVersion);
-	const match = releases.find((r) => stripV(r.raw_version).includes(wanted));
+	const match = releases.find((r) => matchesTargetVersion(stripV(r.raw_version), wanted));
 	return match ? stripV(match.raw_version) : null;
 };
 
@@ -161,7 +180,7 @@ const main = async () => {
 		} catch (e) {
 			err('Error in loop:', e?.message || e);
 		}
-		log(`Will check again in ${checkIntervalRaw}.`);
+		log(`Will check again in ${checkIntervalDisplay}.`);
 		await delay(checkIntervalMs);
 	}
 };

--- a/autohupr/supervisor-update.cjs
+++ b/autohupr/supervisor-update.cjs
@@ -29,14 +29,21 @@ const deviceUuid = process.env.BALENA_DEVICE_UUID;
 const userTargetVersion = (process.env.SUPERVISOR_TARGET_VERSION || '').trim();
 const checkIntervalRaw = process.env.SUPERVISOR_CHECK_INTERVAL || '1d';
 
-for (const [name, value] of [
-	['BALENA_API_KEY', apiKey],
-	['BALENA_API_URL', apiUrl],
-	['BALENA_DEVICE_UUID', deviceUuid],
-]) {
-	if (!value) {
-		err(`${name} required in environment`);
-		process.exit(1);
+// Only require the balena-api credentials when the sidecar is actually
+// enabled. If SUPERVISOR_TARGET_VERSION is empty we want this process to be a
+// pure no-op: hard-exiting here would propagate through start.sh's `wait -n`
+// and take the HUP updater down with us, breaking the documented "the two
+// updaters are independent" contract.
+if (userTargetVersion !== '') {
+	for (const [name, value] of [
+		['BALENA_API_KEY', apiKey],
+		['BALENA_API_URL', apiUrl],
+		['BALENA_DEVICE_UUID', deviceUuid],
+	]) {
+		if (!value) {
+			err(`${name} required in environment when SUPERVISOR_TARGET_VERSION is set`);
+			process.exit(1);
+		}
 	}
 }
 

--- a/autohupr/supervisor-update.cjs
+++ b/autohupr/supervisor-update.cjs
@@ -8,10 +8,12 @@
 //
 // User config:
 //   SUPERVISOR_TARGET_VERSION   '' (disabled) | 'latest' | 'recommended' |
-//                               version substring, e.g. '16.8.2' or '16.8'.
-//                               Do NOT prefix with 'v' — balena-sdk's
-//                               raw_version field has no leading 'v'.
-//   SUPERVISOR_CHECK_INTERVAL   default '1d'. Supports s/m/h/d suffixes.
+//                               a full version like '16.8.2' (exact match) or
+//                               a partial like '16.8' (segment-aware: matches
+//                               '16.8.x' but not '16.80.x'). Do NOT prefix
+//                               with 'v' — balena-sdk's raw_version has none.
+//   SUPERVISOR_CHECK_INTERVAL   default '1d'. Must include a unit (s/m/h/d);
+//                               minimum 1s, maximum ~24.8d.
 
 'use strict';
 
@@ -76,34 +78,37 @@ const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const stripV = (s) => String(s || '').replace(/^v/i, '');
 
-const getCpuArch = async (uuid) => {
+// Single-call fetch: supervisor version + device-type slug + CPU arch slug,
+// via nested $expand. Saves two extra round-trips per tick vs. doing each
+// lookup separately.
+const getDeviceInfo = async (uuid) => {
 	const device = await balena.models.device.get(uuid, {
-		$expand: { is_of__device_type: { $select: 'slug' } },
+		$select: ['supervisor_version'],
+		$expand: {
+			is_of__device_type: {
+				$select: 'slug',
+				$expand: { is_of__cpu_architecture: { $select: 'slug' } },
+			},
+		},
 	});
-	const dtSlug = Array.isArray(device.is_of__device_type)
-		? device.is_of__device_type[0]?.slug
+	const dt = Array.isArray(device.is_of__device_type)
+		? device.is_of__device_type[0]
 		: undefined;
+	const dtSlug = dt?.slug;
 	if (!dtSlug) {
 		throw new Error(`Could not resolve device-type slug for ${uuid}`);
 	}
-	const dt = await balena.models.deviceType.getBySlugOrName(dtSlug, {
-		$select: 'slug',
-		$expand: { is_of__cpu_architecture: { $select: 'slug' } },
-	});
 	const arch = Array.isArray(dt.is_of__cpu_architecture)
 		? dt.is_of__cpu_architecture[0]?.slug
 		: undefined;
 	if (!arch) {
 		throw new Error(`Could not resolve CPU architecture for device-type ${dtSlug}`);
 	}
-	return { dtSlug, arch };
-};
-
-const getCurrentSupervisorVersion = async (uuid) => {
-	const device = await balena.models.device.get(uuid, {
-		$select: ['supervisor_version'],
-	});
-	return stripV(device.supervisor_version || '');
+	return {
+		supervisorVersion: stripV(device.supervisor_version || ''),
+		dtSlug,
+		arch,
+	};
 };
 
 // Segment-aware match: '16.8.2' matches only the exact '16.8.2' (not
@@ -153,8 +158,8 @@ const tick = async () => {
 		await delay(120_000);
 	}
 
-	const { dtSlug, arch } = await getCpuArch(deviceUuid);
-	const currentVersion = await getCurrentSupervisorVersion(deviceUuid);
+	const { supervisorVersion: currentVersion, dtSlug, arch } =
+		await getDeviceInfo(deviceUuid);
 	log(`Current supervisor: ${currentVersion || '(unknown)'} (device type ${dtSlug}, arch ${arch})`);
 
 	const targetVersion = await resolveTargetVersion(arch);


### PR DESCRIPTION
## Summary

Two independent changes in this PR. Happy to split into two PRs if preferred.

### 1. Supervisor update support in `autohupr`

The upstream `balena-io-experimental/autohupr-example` (currently pinned at v0.1.5) only knows how to HUP the host OS. This adds a small Node sidecar — `autohupr/supervisor-update.cjs` — that runs alongside it and keeps the device's balena Supervisor pinned to a configurable target.

The sidecar uses `balena-sdk`:
- `balena.models.device.get(...)` to resolve the device's type and CPU architecture
- `balena.models.os.getSupervisorReleasesForCpuArchitecture(arch)` to enumerate available Supervisor releases (returned newest-first)
- `balena.models.device.setSupervisorRelease(uuid, version)` to pin the target — with a forward-compat fallback to `pinToSupervisorRelease`, which is what the same call is named in balena-sdk ≥ 23 (the v23 changelog renamed it)

`start.sh` is reworked to run both updaters in parallel under `wait -n` with a `SIGTERM/SIGINT` trap, so if either process exits the other is terminated and the container restarts via the compose policy. The two updaters are independent: setting only one target-version variable enables that updater while the other no-ops every check interval. The container labels and `tmpfs: /tmp/work` mount that the upstream HUP needs are unchanged.

New env vars (documented in the README):

- `SUPERVISOR_TARGET_VERSION` — `latest` / `recommended`, or a version substring like `16.8.2` or `16.8`. **No leading `v`** — `balena-sdk` expects `raw_version` (e.g. `16.8.2`), and the sidecar strips a stray `v` defensively.
- `SUPERVISOR_CHECK_INTERVAL` — default `1d`, accepts `s`/`m`/`h`/`d` suffixes.

The sidecar does not reboot the device after setting a new target. The on-device Supervisor updater polls 15 min after boot and every 24 h thereafter, so a new target may take up to a day to land unless the device is rebooted — the README mentions this.

### 2. Bounded retries for the OpenSky package-mirror workflow

`.github/workflows/opensky-version.yml` previously ran a single `aria2c` per arch with `--max-tries=24 --retry-wait=180 --timeout=120`. The run on 2026-05-15 hung for **36 minutes** on a 0 B/0 B transfer to `s3.opensky-network.org` before failing without ever retrying:

```
05/15 02:04:14  Downloading 1 item(s)
05/15 02:40:17  [ERROR] CUID#7 - Download aborted. URI=https://s3.opensky-network.org/.../Packages
                Exception: [AbstractCommand.cc:340] errorCode=2 Timeout.
```

Root cause: aria2's `--timeout` is a socket-inactivity timer and is reset by any low-level TCP activity (keep-alives, ACKs). When S3 accepts the connection but never sends HTTP body bytes, that timer is kept alive by the underlying socket activity, so the configured 120 s never fired. The single attempt eventually died after 36 min — too late for `--max-tries=24` to ever do anything.

Replaced with three `nick-fields/retry@v4.0.0` steps (one per arch), each:

- `timeout_seconds: 60` — hard wall-clock cap per attempt, so a hung S3 connection cannot burn the budget
- `max_attempts: 24` with `retry_wait_seconds: 180` — same retry intent as before, now actually exercised
- aria2 inside is `--max-tries=1`, `--timeout=30`, `--lowest-speed-limit=10K` — the action drives retries; the per-attempt cap stops 0-byte hangs; the speed-limit catches stalls after data starts flowing

Total budget per arch: 24 × 60 s + 23 × 180 s ≈ 81 min. Three sequential arches: ≈ 4 h, fitting in `timeout-minutes: 360` (6 h, set at job level — replaces the previous step-level cap).

## Test plan

- [ ] On a test device, set `SUPERVISOR_TARGET_VERSION=latest` and confirm the sidecar logs `Setting target supervisor release ...` and the dashboard reflects the new pinned release.
- [ ] Leave `SUPERVISOR_TARGET_VERSION` unset and confirm the sidecar logs `SUPERVISOR_TARGET_VERSION not set; skipping` while the HUP path continues unchanged.
- [ ] Set `SUPERVISOR_TARGET_VERSION` to the device's current version and confirm `Already on target supervisor ...`.
- [ ] Confirm `docker stop` of the autohupr service shuts both child processes down cleanly (signal trap in `start.sh`).
- [ ] Trigger the `Mirror OpenSky package file` workflow via `workflow_dispatch` and confirm each arch downloads in seconds on the first attempt.