### PR TITLE
Gate mlat-client behind ENABLED_SERVICES opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,11 +600,11 @@ The reason is always logged before the container stops. Stopping itself requires
 
 ## Custom MLAT client
 
-In the [docker compose file]([https://github.com/ketilmo/balena-ads-b/blob/shawaj/mlat-version/docker-compose.yml](https://github.com/ketilmo/balena-ads-b/blob/master/docker-compose.yml#L258-L271)) you will notice at the bottom there is a section labelled `Optional: Uncomment to enable custom mlat server.` This allows you to share MLAT data with an MLAT server of your choosing, unrelated to any of the above services.
+The `mlat-client` service lets you share MLAT data with an MLAT server of your choosing, unrelated to any of the above services.
 
-In order to enable this, you will need to fork the repo and edit the docker-compose.yml file to remove the `#` at the beginning of each line starting with the one that says `mlat-client`. Once done you should save the file, and then you can deploy it to your fleet using the manual method described above in [Part 2 – Setup balena and configure the device](#part-2--setup-balena-and-configure-the-device).
+To enable it, create a *Device Variable* named `ENABLED_SERVICES` with the value of `mlat-client`. The service is opt-in: if `mlat-client` is not listed in `ENABLED_SERVICES` it asks the balena Supervisor to stop its own container, so devices that do not opt in pay no runtime cost. To enable more than one opt-in service, separate the names with commas (e.g. `ENABLED_SERVICES=mlat-client,otherservice`).
 
-You will also need to add *Device Variables* named `MLAT_CLIENT_USER` with a value of your desired username or UUID and another one named `MLAT_SERVER` with a value or your desired MLAT server address and port. For example you might have an `MLAT_CLIENT_USER` of `0327791e-3777-40a5-addc-aa13408d3b07` and an `MLAT_SERVER` of `feed.mymlatserver.com:31090`.
+Once enabled, add *Device Variables* named `MLAT_CLIENT_USER` with a value of your desired username or UUID and `MLAT_SERVER` with a value of your desired MLAT server address and port. For example you might have an `MLAT_CLIENT_USER` of `0327791e-3777-40a5-addc-aa13408d3b07` and an `MLAT_SERVER` of `feed.mymlatserver.com:31090`. The Supervisor restarts the service when these variables change, so no fork or redeploy is required.
 
 # Part 16 – Updating to the latest version
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -327,18 +327,17 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.tar1090.rule=PathPrefix(`/tar1090`)"
       - "traefik.http.routers.tar1090-a.rule=PathPrefix(`/graphs1090`)"
-# Optional: Uncomment to enable custom mlat server.
-#  mlat-client:
-#    depends_on:
-#      - dump1090-fa
-#    build: ./mlat-client
-#    image: mlat-client
-#    restart: unless-stopped
-#    environment:
-#      - LAT=
-#      - LON=
-#      - ALT=
-#      - MLAT_CLIENT_USER=
-#      - MLAT_SERVER=
-#    labels:
-#      io.balena.features.supervisor-api: '1'
+  mlat-client:
+    depends_on:
+      - dump1090-fa
+    build: ./mlat-client
+    image: mlat-client
+    restart: unless-stopped
+    environment:
+      - LAT=
+      - LON=
+      - ALT=
+      - MLAT_CLIENT_USER=
+      - MLAT_SERVER=
+    labels:
+      io.balena.features.supervisor-api: '1'

--- a/mlat-client/start.sh
+++ b/mlat-client/start.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
-# Check if service has been disabled through the DISABLED_SERVICES environment variable.
+# Check if service has been opted in through the ENABLED_SERVICES environment variable.
 
-if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
-        echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
+if [[ ",$(echo -e "${ENABLED_SERVICES}" | tr -d '[:space:]')," != *",$BALENA_SERVICE_NAME,"* ]]; then
+        echo "$BALENA_SERVICE_NAME is not enabled. Sending request to stop the service:"
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
         echo " "
         sleep infinity


### PR DESCRIPTION
## Summary

- Uncomment the `mlat-client` service in `docker-compose.yml` so it ships in the compose stack by default.
- Gate it at runtime in `mlat-client/start.sh` with the pre-#528 autohupr opt-in pattern: if `mlat-client` is not listed in `ENABLED_SERVICES`, the start script asks the Supervisor to stop the service and sleeps, so devices that do not opt in pay no runtime cost.
- Rewrite the README "Custom MLAT client" section: users now enable it by setting `ENABLED_SERVICES=mlat-client` plus `MLAT_CLIENT_USER` and `MLAT_SERVER`. No fork or redeploy required.

Closes #198.

## Test plan

- [ ] Deploy with no `ENABLED_SERVICES`: `mlat-client` logs `is not enabled`, calls Supervisor `stop-service`, and stays stopped.
- [ ] Deploy with `ENABLED_SERVICES=mlat-client` but missing `MLAT_SERVER` / `MLAT_CLIENT_USER` / `LAT` / `LON` / `ALT`: container logs the missing variable and idles.
- [ ] Deploy with `ENABLED_SERVICES=mlat-client` and all required variables set: `mlat-client` connects to the configured server and feeds.
- [ ] Toggle `ENABLED_SERVICES` at runtime: Supervisor restarts the service and the gate re-evaluates.