### PR TITLE
Extend OpenSky download retries to fill workflow timeout

### DIFF
--- a/.github/workflows/opensky-version.yml
+++ b/.github/workflows/opensky-version.yml
@@ -26,7 +26,7 @@ jobs:
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_seconds: 60
-          max_attempts: 24
+          max_attempts: 200
           retry_wait_seconds: 180
           shell: bash
           command: |
@@ -43,7 +43,7 @@ jobs:
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_seconds: 60
-          max_attempts: 24
+          max_attempts: 200
           retry_wait_seconds: 180
           shell: bash
           command: |
@@ -60,7 +60,7 @@ jobs:
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_seconds: 60
-          max_attempts: 24
+          max_attempts: 200
           retry_wait_seconds: 180
           shell: bash
           command: |


### PR DESCRIPTION
Bumps max_attempts from 24 to 200 on all three nick-fields/retry blocks in opensky-version.yml. Previously each step gave up after ~84 min (24 * (60s + 180s)), failing the job well before the 360-min timeout-minutes ceiling. With 200 attempts the job-level timeout becomes the binding constraint, so transient OpenSky S3 outages get the full 6-hour retry window instead of bailing early.