### PR TITLE
feat(tailscale): add opt-in Tailscale remote-access service

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ To enable it, create a *Device Variable* named `ENABLED_SERVICES` with the value
 Three authentication methods are supported. All are configured through the same `TS_AUTHKEY` *Device Variable*; the value's prefix determines the mode.
 
 - **Pre-auth key** (simplest). In your Tailscale admin console, go to *Settings → Keys → Generate auth key*. Set `TS_AUTHKEY` to the resulting `tskey-auth-…` string. Tag the key (for example `tag:adsb`) so you can write ACLs against the device.
-- **OAuth client** (recommended for fleets, integrates with your SSO). In your Tailscale admin console, go to *Settings → OAuth clients* and create a client with the `auth_keys` scope and the tag(s) you want devices to inherit. Set `TS_AUTHKEY` to the resulting `tskey-client-…?ephemeral=false&preauthorized=true` string. The OAuth client is tied to the SSO-authenticated identity that created it, so devices joining with this credential are auditable back to that identity.
+- **OAuth client** (recommended for fleets, integrates with your SSO). In your Tailscale admin console go to *Settings → Trust credentials* and press *+ Credential*; pick *OAuth client*, add a description, and grant the *Auth Keys* scope (under *Keys*) `read` + `write` permissions, selecting the tag(s) the client may issue keys for. Set `TS_AUTHKEY` to the resulting `tskey-client-…?ephemeral=false&preauthorized=true` string. Because the `write` scope only issues tagged keys, the device must also advertise a matching tag — set `TS_EXTRA_ARGS=--advertise-tags=tag:adsb` (substituting your tag) or tailscaled refuses to start with `oauth authkeys require --advertise-tags`. The OAuth client is tied to the SSO-authenticated identity that created it, so devices joining with this credential are auditable back to that identity.
 - **Interactive SSO via login URL**. Leave `TS_AUTHKEY` unset. The service prints a one-time login URL in a clearly-marked banner to the container logs (visible in the balenaCloud dashboard or via `balena logs --tail`); open it in a browser that is signed in to your tailnet's SSO provider (Google, Microsoft, Okta, etc.) and approve the device. State is persisted to the `tailscale-state` volume so this is a one-time step per device. Note that each container restart with no existing state generates a fresh URL — only the most recent one is valid.
 
 The Supervisor restarts the service when `TS_AUTHKEY` changes, so no fork or redeploy is required.
@@ -642,7 +642,7 @@ The Supervisor restarts the service when `TS_AUTHKEY` changes, so no fork or red
 - `TS_HOSTNAME` (default: the balena device name): The hostname registered with the tailnet. Override if you want a different MagicDNS name.
 - `TAILSCALE_SERVE_TRAEFIK` (default: `false`): When `true`, runs [Tailscale Serve](https://tailscale.com/kb/1312/serve) in front of traefik so `https://<device>.<tailnet>.ts.net/` proxies to traefik with an automatically-issued TLS certificate.
 - `TS_ROUTES` (default: unset): Comma-separated CIDRs to advertise as a [subnet route](https://tailscale.com/kb/1019/subnets) (for example `192.168.1.0/24` to reach your LAN). You must approve the route in the Tailscale admin console after the device first checks in.
-- `TS_EXTRA_ARGS` (default: unset): Additional arguments passed to `tailscale up`. Useful values include `--ssh` to enable Tailscale SSH and `--advertise-tags=tag:adsb`.
+- `TS_EXTRA_ARGS` (default: unset): Additional arguments passed to `tailscale up`. Useful values include `--ssh` to enable Tailscale SSH and `--advertise-tags=tag:adsb` (required when authenticating via the OAuth client flow above).
 - `TS_ACCEPT_DNS` (default: `false`): When `true`, the device uses MagicDNS for name resolution. Off by default to avoid clashing with balena's resolver.
 - `TS_EXCLUDED_INTERFACES` (default: `resin-vpn resin-dns`): Interfaces hidden from tailscaled's interface enumeration. The defaults keep Tailscale from picking balena's management-VPN interfaces as default-route candidates; you rarely need to change this.
 - `TS_UPDATE_CHECK` (default: `false`): When `false`, disables tailscaled's outbound update-check probes. Set to `true` if you want tailscaled to notify you about new Tailscale versions in its logs.
@@ -663,6 +663,12 @@ The Supervisor restarts the service when `TS_AUTHKEY` changes, so no fork or red
     ]
   }
   ```
+
+- **tailscaled cannot reach the control plane (TLS or DNS errors in the logs).** Custom upstream DNS — particularly ad-blocking resolvers like Pi-hole, AdGuard, or NextDNS — can block the names tailscaled needs to bootstrap, leaving the daemon unable to talk to the coordination or DERP servers. If the device sits behind such a resolver, allow the names listed in the Tailscale [DNS reference](https://tailscale.com/docs/reference/dns-in-tailscale) through the filter, or temporarily point the device at a public resolver to confirm DNS is the culprit.
+
+- **Service is in a crash-loop after a configuration change.** Because the `tailscale-state` volume persists across restarts, a corrupt or unwanted preferences blob keeps tailscaled crashing on every boot. Two recovery paths:
+  - Set `TS_EXTRA_ARGS=--reset` once (combine with any existing flags, e.g. `--reset --advertise-tags=tag:adsb` when using OAuth). tailscaled clears its preferences on the next start and rejoins the tailnet automatically if `TS_AUTHKEY` is set; remove `--reset` afterwards so subsequent restarts resume normally.
+  - Or wipe the contents of the `tailscale-state` volume. The simplest path is to open a shell in the running container — `balena ssh <device-uuid> tailscale` from the CLI, or the *Web terminal* on the device's balenaCloud page — run `rm -rf /var/lib/tailscale/*`, and restart the service.
 
 # Part 16 – Updating to the latest version
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Software packages downloaded, installed, and configured by the balena-ads-b scri
     * [Automatic balenaOS host updates](#automatic-balenaos-host-updates)
     * [Ident operator console](#ident-operator-console)
     * [Custom MLAT client](#custom-mlat-client)
+    * [Tailscale remote access](#tailscale-remote-access)
 - [Part 16 – Updating to the latest version](#part-16--updating-to-the-latest-version)
 
 # Part 1 – Build the receiver
@@ -617,6 +618,51 @@ The `mlat-client` service lets you share MLAT data with an MLAT server of your c
 To enable it, create a *Device Variable* named `ENABLED_SERVICES` with the value of `mlat-client`. The service is opt-in: if `mlat-client` is not listed in `ENABLED_SERVICES` it asks the balena Supervisor to stop its own container, so devices that do not opt in pay no runtime cost. To enable more than one opt-in service, separate the names with commas (e.g. `ENABLED_SERVICES=mlat-client,otherservice`).
 
 Once enabled, add *Device Variables* named `MLAT_CLIENT_USER` with a value of your desired username or UUID and `MLAT_SERVER` with a value of your desired MLAT server address and port. For example you might have an `MLAT_CLIENT_USER` of `0327791e-3777-40a5-addc-aa13408d3b07` and an `MLAT_SERVER` of `feed.mymlatserver.com:31090`. The Supervisor restarts the service when these variables change, so no fork or redeploy is required.
+
+## Tailscale remote access
+
+The `tailscale` service joins your device to a [Tailscale](https://tailscale.com/) tailnet so you can reach the receiver — and every web UI it serves — from anywhere, without exposing anything to the public internet or relying on balena's *Public Device URL*. It runs on top of the prebuilt [`klutchell/balena-tailscale`](https://github.com/klutchell/balena-tailscale) block.
+
+The service runs in host network mode, so the device's tailnet IP automatically reaches every port the rest of the stack already publishes. From any other machine on the same tailnet, the URLs from [Part 14](#part-14--exploring-flight-traffic-locally-on-your-device) work exactly the same — just swap `YOURIP` for `<device>.<tailnet>.ts.net`.
+
+To enable it, create a *Device Variable* named `ENABLED_SERVICES` with the value of `tailscale`. The service is opt-in: if `tailscale` is not listed in `ENABLED_SERVICES` it asks the balena Supervisor to stop its own container, so devices that do not opt in pay no runtime cost. To enable more than one opt-in service, separate the names with commas (e.g. `ENABLED_SERVICES=mlat-client,tailscale`).
+
+### Authenticating the device
+
+Three authentication methods are supported. All are configured through the same `TS_AUTHKEY` *Device Variable*; the value's prefix determines the mode.
+
+- **Pre-auth key** (simplest). In your Tailscale admin console, go to *Settings → Keys → Generate auth key*. Set `TS_AUTHKEY` to the resulting `tskey-auth-…` string. Tag the key (for example `tag:adsb`) so you can write ACLs against the device.
+- **OAuth client** (recommended for fleets, integrates with your SSO). In your Tailscale admin console, go to *Settings → OAuth clients* and create a client with the `auth_keys` scope and the tag(s) you want devices to inherit. Set `TS_AUTHKEY` to the resulting `tskey-client-…?ephemeral=false&preauthorized=true` string. The OAuth client is tied to the SSO-authenticated identity that created it, so devices joining with this credential are auditable back to that identity.
+- **Interactive SSO via login URL**. Leave `TS_AUTHKEY` unset. The service prints a one-time login URL in a clearly-marked banner to the container logs (visible in the balenaCloud dashboard or via `balena logs --tail`); open it in a browser that is signed in to your tailnet's SSO provider (Google, Microsoft, Okta, etc.) and approve the device. State is persisted to the `tailscale-state` volume so this is a one-time step per device. Note that each container restart with no existing state generates a fresh URL — only the most recent one is valid.
+
+The Supervisor restarts the service when `TS_AUTHKEY` changes, so no fork or redeploy is required.
+
+### Optional configuration
+
+- `TS_HOSTNAME` (default: the balena device name): The hostname registered with the tailnet. Override if you want a different MagicDNS name.
+- `TAILSCALE_SERVE_TRAEFIK` (default: `false`): When `true`, runs [Tailscale Serve](https://tailscale.com/kb/1312/serve) in front of traefik so `https://<device>.<tailnet>.ts.net/` proxies to traefik with an automatically-issued TLS certificate.
+- `TS_ROUTES` (default: unset): Comma-separated CIDRs to advertise as a [subnet route](https://tailscale.com/kb/1019/subnets) (for example `192.168.1.0/24` to reach your LAN). You must approve the route in the Tailscale admin console after the device first checks in.
+- `TS_EXTRA_ARGS` (default: unset): Additional arguments passed to `tailscale up`. Useful values include `--ssh` to enable Tailscale SSH and `--advertise-tags=tag:adsb`.
+- `TS_ACCEPT_DNS` (default: `false`): When `true`, the device uses MagicDNS for name resolution. Off by default to avoid clashing with balena's resolver.
+- `TS_EXCLUDED_INTERFACES` (default: `resin-vpn resin-dns`): Interfaces hidden from tailscaled's interface enumeration. The defaults keep Tailscale from picking balena's management-VPN interfaces as default-route candidates; you rarely need to change this.
+- `TS_UPDATE_CHECK` (default: `false`): When `false`, disables tailscaled's outbound update-check probes. Set to `true` if you want tailscaled to notify you about new Tailscale versions in its logs.
+- `TS_POST_UP_SET_ARGS` (default: unset): Additional arguments appended verbatim (space-separated) to a single `tailscale set` invocation that runs after the daemon reaches the *Running* state. Use it to apply any other persistent preference (for example `--shields-up=true`) without editing `start.sh`.
+
+### Troubleshooting
+
+- **Logs contain `open-conn-track: timeout opening (TCP <tailnet-ip>:… => x.x.x.x:443); no associated peer node` warnings.** These are mostly tailscaled's captive-portal probes leaking from the tailnet interface. Disable captive-portal detection cluster-wide by adding a `nodeAttrs` rule to your tailnet ACL (admin console → *Access Controls*):
+
+  ```jsonc
+  {
+    // …existing policy…
+    "nodeAttrs": [
+      {
+        "target": ["*"],                              // or scope to ["tag:adsb"] if you tag balena nodes
+        "attr":   ["disable-captive-portal-detection"]
+      }
+    ]
+  }
+  ```
 
 # Part 16 – Updating to the latest version
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ volumes:
   tar1090-collectd:
   tar1090-log:
   aircraft-data:
+  tailscale-state:
 services:
   kiosk:
     restart: unless-stopped
@@ -383,3 +384,39 @@ services:
       - "traefik.http.middlewares.ident-redirect.redirectregex.regex=^.*/ident$$"
       - "traefik.http.middlewares.ident-redirect.redirectregex.replacement=/ident/"
       - "traefik.http.middlewares.ident-redirect.redirectregex.permanent=true"
+  tailscale:
+    build: ./tailscale
+    image: tailscale
+    restart: unless-stopped
+    network_mode: host
+    privileged: true
+    tmpfs:
+      - /tmp
+      - /var/run/
+    environment:
+      - TS_AUTHKEY=
+      - TS_HOSTNAME=
+      - TS_EXTRA_ARGS=
+      - TS_ROUTES=
+      - TS_ACCEPT_DNS=false
+      - TS_USERSPACE=false
+      # resin-vpn / resin-dns are balena's management-VPN interfaces;
+      # excluding them keeps tailscaled's netmon from picking them as
+      # default-route candidates (see patches/01-custom-interfaces.patch).
+      - TS_EXCLUDED_INTERFACES=resin-vpn resin-dns
+      - TAILSCALE_SERVE_TRAEFIK=false
+      # Disable tailscaled's outbound update-check probes. The check uses
+      # tailscale's userspace dialer, which can pick the tailnet interface
+      # as the source and produce a stream of open-conn-track timeouts to
+      # pkgs.tailscale.com (Cloudflare-fronted). Applied post-up via
+      # `tailscale set --update-check=$value` in start.sh.
+      - TS_UPDATE_CHECK=false
+      # Escape hatch for arbitrary post-up `tailscale set` args, appended
+      # verbatim (space-separated). Use the balena dashboard's service
+      # variables to override without editing this file.
+      - TS_POST_UP_SET_ARGS=
+    volumes:
+      - 'tailscale-state:/var/lib/tailscale'
+    labels:
+      io.balena.features.supervisor-api: '1'
+      io.balena.features.kernel-modules: '1'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -405,15 +405,11 @@ services:
       # default-route candidates.
       - TS_EXCLUDED_INTERFACES=resin-vpn resin-dns
       - TAILSCALE_SERVE_TRAEFIK=false
-      # Disable tailscaled's outbound update-check probes. The check uses
-      # tailscale's userspace dialer, which can pick the tailnet interface
-      # as the source and produce a stream of open-conn-track timeouts to
-      # pkgs.tailscale.com (Cloudflare-fronted). Applied post-up via
+      # Disable tailscaled's outbound update-check probes. Applied post-up via
       # `tailscale set --update-check=$value` in start.sh.
       - TS_UPDATE_CHECK=false
       # Escape hatch for arbitrary post-up `tailscale set` args, appended
-      # verbatim (space-separated). Use the balena dashboard's service
-      # variables to override without editing this file.
+      # verbatim (space-separated).
       - TS_POST_UP_SET_ARGS=
     volumes:
       - 'tailscale-state:/var/lib/tailscale'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -402,7 +402,7 @@ services:
       - TS_USERSPACE=false
       # resin-vpn / resin-dns are balena's management-VPN interfaces;
       # excluding them keeps tailscaled's netmon from picking them as
-      # default-route candidates (see patches/01-custom-interfaces.patch).
+      # default-route candidates.
       - TS_EXCLUDED_INTERFACES=resin-vpn resin-dns
       - TAILSCALE_SERVE_TRAEFIK=false
       # Disable tailscaled's outbound update-check probes. The check uses

--- a/renovate.json
+++ b/renovate.json
@@ -224,6 +224,12 @@
         "{ \"releases\": [{ \"version\": $[0].releases.version.$match(/pfclient_([0-9.]+)_armhf\\.tar\\.gz/).groups[0] }] }"
       ],
       "format": "plain"
+    },
+    "klutchell-balena-tailscale": {
+      "defaultRegistryUrlTemplate": "https://api.balena-cloud.com/v7/release?$filter=belongs_to__application%20eq%201985463%20and%20status%20eq%20'success'&$select=semver&$orderby=created_at%20desc&$top=200",
+      "transformTemplates": [
+        "{ \"releases\": d.{ \"version\": semver } }"
+      ]
     }
   },
   "packageRules": [

--- a/tailscale/Dockerfile.template
+++ b/tailscale/Dockerfile.template
@@ -1,0 +1,13 @@
+# renovate: datasource=github-tags depName=klutchell/balena-tailscale versioning=loose
+ARG TAILSCALE_VERSION=1.98.3
+FROM bh.cr/gh_klutchell/tailscale-%%BALENA_ARCH%%/$TAILSCALE_VERSION AS base
+LABEL maintainer="https://github.com/ketilmo"
+
+RUN apk add --no-cache tini curl
+
+COPY start.sh /start.sh
+COPY serve.json /etc/tailscale/serve.json
+
+RUN chmod +x /start.sh
+
+ENTRYPOINT ["/sbin/tini", "--", "/start.sh"]

--- a/tailscale/Dockerfile.template
+++ b/tailscale/Dockerfile.template
@@ -1,4 +1,4 @@
-# renovate: datasource=github-tags depName=klutchell/balena-tailscale versioning=loose
+# renovate: datasource=custom.klutchell-balena-tailscale depName=tailscale
 ARG TAILSCALE_VERSION=1.98.3
 FROM bh.cr/gh_klutchell/tailscale-%%BALENA_ARCH%%/$TAILSCALE_VERSION AS base
 LABEL maintainer="https://github.com/ketilmo"

--- a/tailscale/serve.json
+++ b/tailscale/serve.json
@@ -1,0 +1,16 @@
+{
+  "TCP": {
+    "443": {
+      "HTTPS": true
+    }
+  },
+  "Web": {
+    "${TS_CERT_DOMAIN}:443": {
+      "Handlers": {
+        "/": {
+          "Proxy": "http://127.0.0.1:80"
+        }
+      }
+    }
+  }
+}

--- a/tailscale/start.sh
+++ b/tailscale/start.sh
@@ -198,16 +198,19 @@ fi
 #   * `[RATELIMIT] format("magicsock: derp-%d does not know about
 #     peer …")` — tailscaled's rate-limiter meta-line for the above.
 #
-# We route via a FIFO + background awk reader rather than the obvious
-# `exec containerboot | awk` pipeline so that containerboot remains
-# tini's direct child: a pipeline would replace this shell with awk,
-# breaking SIGTERM forwarding to containerboot and masking its exit
-# code. With the FIFO, containerboot is exec'd into the current
-# process (so its PID is tini's child) and writes to the FIFO; awk
-# reads, filters, and emits to the inherited container stdout. When
-# containerboot exits, the FIFO write side closes and awk reaches
-# EOF on its own; tini reaps both. awk is in busybox and we call
-# fflush() per line so balena's log shipper sees output promptly.
+# We route via a transient FIFO + background awk reader rather than
+# the obvious `exec containerboot | awk` pipeline so containerboot
+# remains tini's direct child: a pipeline would replace this shell
+# with awk, breaking SIGTERM forwarding to containerboot and masking
+# its exit code. We `mkfifo`, open both ends, then immediately
+# `rm -f` the inode — the kernel pipe object stays alive via the
+# open fds, so no on-disk artifact persists past startup (and /tmp
+# is tmpfs anyway, so even the transient inode is RAM-only). awk
+# reads filtered output to the inherited container stdout. When
+# containerboot exits, every fd that referenced the FIFO write side
+# closes and awk reaches EOF on its own; tini reaps both. awk ships
+# in busybox; we call fflush() per line so balena's log shipper sees
+# output promptly.
 
 LOG_FIFO=/tmp/ts-log.fifo
 rm -f "$LOG_FIFO"
@@ -220,4 +223,13 @@ awk '
 	{ print; fflush() }
 ' < "$LOG_FIFO" &
 
-exec /usr/local/bin/containerboot > "$LOG_FIFO" 2>&1
+# Open the FIFO write end on fd 3 in this shell so we can unlink the
+# inode while the pipe is still in use. Both opens rendezvous here:
+# the background awk's `< "$LOG_FIFO"` and this `3>"$LOG_FIFO"`.
+exec 3> "$LOG_FIFO"
+rm -f "$LOG_FIFO"
+
+# Replace this shell with containerboot, redirecting its stdout and
+# stderr to fd 3 (the FIFO write end). containerboot is now tini's
+# direct child with the same PID this script had.
+exec /usr/local/bin/containerboot 1>&3 2>&3

--- a/tailscale/start.sh
+++ b/tailscale/start.sh
@@ -75,7 +75,13 @@ esac
 
 if [ -z "${TS_AUTHKEY:-}" ]; then
 	(
+		s=0
 		while [ ! -S /var/run/tailscale/tailscaled.sock ]; do
+			s=$((s + 1))
+			if [ "$s" -gt 180 ]; then
+				echo "Tailscale SSO URL poller: tailscaled socket never appeared after 3 minutes; giving up."
+				exit 0
+			fi
 			sleep 1
 		done
 		i=0
@@ -120,7 +126,15 @@ fi
 
 if [ -n "${TS_UPDATE_CHECK:-}" ] || [ -n "${TS_POST_UP_SET_ARGS:-}" ]; then
 	(
-		while [ ! -S /var/run/tailscale/tailscaled.sock ]; do sleep 1; done
+		s=0
+		while [ ! -S /var/run/tailscale/tailscaled.sock ]; do
+			s=$((s + 1))
+			if [ "$s" -gt 180 ]; then
+				echo "tailscale set: tailscaled socket never appeared after 3 minutes; skipping post-up runner."
+				exit 0
+			fi
+			sleep 1
+		done
 
 		# Stage 1: push --update-check as soon as the LocalAPI accepts
 		# prefs edits (any non-empty BackendState).

--- a/tailscale/start.sh
+++ b/tailscale/start.sh
@@ -126,6 +126,11 @@ fi
 
 if [ -n "${TS_UPDATE_CHECK:-}" ] || [ -n "${TS_POST_UP_SET_ARGS:-}" ]; then
 	(
+		# Disable pathname expansion inside this subshell so that
+		# TS_POST_UP_SET_ARGS values containing glob characters
+		# (e.g. tag patterns with `*`, `?`, `[...]`) survive the
+		# unquoted expansion below without globbing against the CWD.
+		set -f
 		s=0
 		while [ ! -S /var/run/tailscale/tailscaled.sock ]; do
 			s=$((s + 1))

--- a/tailscale/start.sh
+++ b/tailscale/start.sh
@@ -202,5 +202,6 @@ fi
 exec /usr/local/bin/containerboot 2>&1 | awk '
 	/localapi: \[POST\] \/localapi\/v0\/debug/ { next }
 	/magicsock: derp-[0-9]+ does not know about peer/ { next }
+	/\[RATELIMIT\] format\("magicsock: derp-%d does not know about peer/ { next }
 	{ print; fflush() }
 '

--- a/tailscale/start.sh
+++ b/tailscale/start.sh
@@ -173,12 +173,15 @@ if [ -n "${TS_UPDATE_CHECK:-}" ] || [ -n "${TS_POST_UP_SET_ARGS:-}" ]; then
 			echo "tailscale set: backend did not reach Running within 2 minutes; skipping."
 			exit 0
 		fi
-		SET_ARGS=""
-		[ -n "${TS_UPDATE_CHECK:-}" ] && SET_ARGS="$SET_ARGS --update-check=$TS_UPDATE_CHECK"
-		[ -n "${TS_POST_UP_SET_ARGS:-}" ] && SET_ARGS="$SET_ARGS $TS_POST_UP_SET_ARGS"
-		echo "Applying post-up tailscale set:$SET_ARGS"
-		# shellcheck disable=SC2086   # intentional word-splitting on SET_ARGS
-		/usr/local/bin/tailscale set $SET_ARGS || \
+		# Build the argument vector via positional parameters so
+		# --update-check is always one quoted arg, while $TS_POST_UP_SET_ARGS
+		# is intentionally space-split into multiple flags.
+		set --
+		[ -n "${TS_UPDATE_CHECK:-}" ] && set -- "$@" "--update-check=$TS_UPDATE_CHECK"
+		# shellcheck disable=SC2086   # intentional word-splitting on TS_POST_UP_SET_ARGS
+		[ -n "${TS_POST_UP_SET_ARGS:-}" ] && set -- "$@" $TS_POST_UP_SET_ARGS
+		echo "Applying post-up tailscale set: $*"
+		/usr/local/bin/tailscale set "$@" || \
 			echo "tailscale set failed (exit $?); continuing."
 	) &
 fi

--- a/tailscale/start.sh
+++ b/tailscale/start.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env sh
+set -e
+
+# Check if service has been opted in through the ENABLED_SERVICES environment variable.
+
+case ",$(echo "${ENABLED_SERVICES:-}" | tr -d '[:space:]')," in
+	*",${BALENA_SERVICE_NAME},"*)
+		;;
+	*)
+		echo "$BALENA_SERVICE_NAME is not enabled. Sending request to stop the service:"
+		curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'"$BALENA_SERVICE_NAME"'"}'
+		echo " "
+		sleep infinity
+		;;
+esac
+
+# Announce the chosen authentication method. Three are supported:
+#
+#   1. Pre-auth key:    TS_AUTHKEY=tskey-auth-…   (Admin console → Settings → Keys)
+#   2. OAuth client:    TS_AUTHKEY=tskey-client-…?ephemeral=false&preauthorized=true
+#                       (Admin console → Settings → OAuth clients; recommended
+#                       for fleets backed by SSO since the client inherits the
+#                       authenticated identity)
+#   3. Interactive SSO: TS_AUTHKEY left empty. tailscaled prints a one-time
+#                       login URL to the container logs; open it in your
+#                       SSO-enabled browser to authorize the device.
+
+if [ -z "${TS_AUTHKEY:-}" ]; then
+	echo "TS_AUTHKEY is not set – Tailscale will print an interactive login URL"
+	echo "to the container logs. Open it in your SSO-enabled browser to authorize"
+	echo "this device, or set TS_AUTHKEY to a pre-auth key / OAuth client secret."
+else
+	echo "TS_AUTHKEY is set, proceeding with non-interactive authentication."
+fi
+
+echo " "
+
+# balena-friendly defaults; only set when the user has not overridden.
+
+: "${TS_USERSPACE:=false}"
+: "${TS_ACCEPT_DNS:=false}"
+: "${TS_HOSTNAME:=${BALENA_DEVICE_NAME_AT_INIT:-}}"
+: "${TS_EXCLUDED_INTERFACES:=resin-vpn resin-dns}"
+export TS_USERSPACE TS_ACCEPT_DNS TS_HOSTNAME TS_EXCLUDED_INTERFACES
+
+# Kernel-mode tailscaled needs /dev/net/tun. balenaOS usually exposes the host
+# device via io.balena.features.kernel-modules, but on some base images we
+# still have to mknod it ourselves.
+
+modprobe tun 2>/dev/null || true
+modprobe wireguard 2>/dev/null || true
+mkdir -p /dev/net
+if [ ! -c /dev/net/tun ]; then
+	mknod /dev/net/tun c 10 200
+fi
+
+mount -o remount,rw /proc/sys 2>/dev/null || \
+	echo "remount /proc/sys rw failed; tailscaled will warn about src_valid_mark and connmark rp_filter workaround will be ineffective."
+
+# Optional: terminate Tailscale Serve (HTTPS on :443) in front of traefik. The
+# file ships unmodified — ${TS_CERT_DOMAIN} inside is a magic placeholder
+# tailscaled substitutes for the device's tailnet hostname at runtime.
+
+case "$(echo "${TAILSCALE_SERVE_TRAEFIK:-}" | tr '[:upper:]' '[:lower:]')" in
+	true|yes|on|1|y|enable|enabled)
+		export TS_SERVE_CONFIG=/etc/tailscale/serve.json
+		;;
+esac
+
+# In interactive-SSO mode (TS_AUTHKEY empty) tailscaled emits a one-time login
+# URL on first boot. Background-poll the LocalAPI so the URL surfaces as a
+# clear banner in the container logs rather than buried in normal startup
+# chatter. The poller exits on its own once the URL is shown or the backend
+# reaches Running, so it does not linger past first authentication.
+
+if [ -z "${TS_AUTHKEY:-}" ]; then
+	(
+		while [ ! -S /var/run/tailscale/tailscaled.sock ]; do
+			sleep 1
+		done
+		i=0
+		while [ "$i" -lt 120 ]; do
+			STATUS=$(/usr/local/bin/tailscale status --json 2>/dev/null || true)
+			# `tailscale status --json` pretty-prints with `"key": "value"`
+			# (space after colon); the regex permits zero-or-more spaces so
+			# both pretty and compact JSON are handled.
+			URL=$(echo "$STATUS" | sed -n 's/.*"AuthURL"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+			BACKEND=$(echo "$STATUS" | sed -n 's/.*"BackendState"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+			if [ -n "$URL" ]; then
+				printf '\n========================================================================\n'
+				printf 'Tailscale needs interactive sign-in. Open this URL in an SSO-signed-in\n'
+				printf 'browser to authorize this device:\n'
+				printf '    %s\n' "$URL"
+				printf '========================================================================\n\n'
+				break
+			fi
+			if [ "$BACKEND" = "Running" ]; then
+				break
+			fi
+			i=$((i + 1))
+			sleep 2
+		done
+		if [ "$i" -ge 120 ]; then
+			echo "Tailscale SSO URL poller: gave up after 4 minutes without finding URL or Running state."
+		fi
+	) &
+fi
+
+# Optional post-up `tailscale set` preferences. Two layers:
+#   TS_UPDATE_CHECK      convenience var; if non-empty, becomes
+#                        --update-check=$value. Disables tailscaled's
+#                        outbound update-check probes.
+#   TS_POST_UP_SET_ARGS  escape hatch; raw `tailscale set` args appended
+#                        verbatim (space-separated).
+# Both feed a single `tailscale set` invocation, run after tailscaled
+# reaches the Running state. Skipped silently if neither var is set.
+
+if [ -n "${TS_UPDATE_CHECK:-}" ] || [ -n "${TS_POST_UP_SET_ARGS:-}" ]; then
+	(
+		while [ ! -S /var/run/tailscale/tailscaled.sock ]; do sleep 1; done
+
+		# Stage 1: push --update-check as soon as the LocalAPI accepts
+		# prefs edits (any non-empty BackendState).
+		if [ -n "${TS_UPDATE_CHECK:-}" ]; then
+			k=0
+			while [ "$k" -lt 30 ]; do
+				BACKEND=$(/usr/local/bin/tailscale status --json 2>/dev/null \
+					| sed -n 's/.*"BackendState"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+				if [ -n "$BACKEND" ]; then
+					/usr/local/bin/tailscale set --update-check="$TS_UPDATE_CHECK" \
+						|| echo "early tailscale set --update-check failed (exit $?); will retry post-Running."
+					break
+				fi
+				k=$((k + 1))
+				sleep 1
+			done
+		fi
+
+		# Stage 2: wait for Running, then apply TS_POST_UP_SET_ARGS (and
+		# re-apply --update-check defensively in case stage 1 lost the race).
+		j=0
+		BACKEND=""
+		while [ "$j" -lt 60 ]; do
+			BACKEND=$(/usr/local/bin/tailscale status --json 2>/dev/null \
+				| sed -n 's/.*"BackendState"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+			[ "$BACKEND" = "Running" ] && break
+			j=$((j + 1))
+			sleep 2
+		done
+		if [ "$BACKEND" != "Running" ]; then
+			echo "tailscale set: backend did not reach Running within 2 minutes; skipping."
+			exit 0
+		fi
+		SET_ARGS=""
+		[ -n "${TS_UPDATE_CHECK:-}" ] && SET_ARGS="$SET_ARGS --update-check=$TS_UPDATE_CHECK"
+		[ -n "${TS_POST_UP_SET_ARGS:-}" ] && SET_ARGS="$SET_ARGS $TS_POST_UP_SET_ARGS"
+		echo "Applying post-up tailscale set:$SET_ARGS"
+		# shellcheck disable=SC2086   # intentional word-splitting on SET_ARGS
+		/usr/local/bin/tailscale set $SET_ARGS || \
+			echo "tailscale set failed (exit $?); continuing."
+	) &
+fi
+
+# Hand off to upstream containerboot.
+
+exec /usr/local/bin/containerboot

--- a/tailscale/start.sh
+++ b/tailscale/start.sh
@@ -186,6 +186,21 @@ if [ -n "${TS_UPDATE_CHECK:-}" ] || [ -n "${TS_POST_UP_SET_ARGS:-}" ]; then
 	) &
 fi
 
-# Hand off to upstream containerboot.
+# Hand off to upstream containerboot, piping its combined output through
+# awk so we can drop two well-known cosmetic log lines that the upstream
+# image has no knob to silence:
+#   * `localapi: [POST] /localapi/v0/debug` — containerboot's own 15s
+#     peerPoll watcher hitting the local LocalAPI debug action. Unix
+#     socket only, no network I/O, fires every 15s for the life of the
+#     container.
+#   * `magicsock: derp-NN does not know about peer [XX/YY], removing
+#     route` — disco probe spam against an offline peer's cached home
+#     DERP region; loops every ~5s until that peer reconnects.
+# awk is in busybox, doesn't need GNU-grep's --line-buffered, and we
+# call fflush() to keep balena's log shipper seeing lines promptly.
 
-exec /usr/local/bin/containerboot
+exec /usr/local/bin/containerboot 2>&1 | awk '
+	/localapi: \[POST\] \/localapi\/v0\/debug/ { next }
+	/magicsock: derp-[0-9]+ does not know about peer/ { next }
+	{ print; fflush() }
+'

--- a/tailscale/start.sh
+++ b/tailscale/start.sh
@@ -108,12 +108,15 @@ fi
 
 # Optional post-up `tailscale set` preferences. Two layers:
 #   TS_UPDATE_CHECK      convenience var; if non-empty, becomes
-#                        --update-check=$value. Disables tailscaled's
-#                        outbound update-check probes.
+#                        --update-check=$value (true|false), toggling
+#                        tailscaled's outbound update-check probes.
 #   TS_POST_UP_SET_ARGS  escape hatch; raw `tailscale set` args appended
 #                        verbatim (space-separated).
-# Both feed a single `tailscale set` invocation, run after tailscaled
-# reaches the Running state. Skipped silently if neither var is set.
+# Applied in two stages: stage 1 pushes --update-check as soon as the
+# LocalAPI accepts prefs edits (any non-empty BackendState); stage 2
+# waits for BackendState=Running and applies TS_POST_UP_SET_ARGS,
+# re-applying --update-check defensively. Skipped silently if neither
+# var is set.
 
 if [ -n "${TS_UPDATE_CHECK:-}" ] || [ -n "${TS_POST_UP_SET_ARGS:-}" ]; then
 	(

--- a/tailscale/start.sh
+++ b/tailscale/start.sh
@@ -186,22 +186,38 @@ if [ -n "${TS_UPDATE_CHECK:-}" ] || [ -n "${TS_POST_UP_SET_ARGS:-}" ]; then
 	) &
 fi
 
-# Hand off to upstream containerboot, piping its combined output through
-# awk so we can drop two well-known cosmetic log lines that the upstream
-# image has no knob to silence:
+# Hand off to upstream containerboot, with its combined output funneled
+# through an awk filter that drops three known cosmetic log lines the
+# upstream image has no knob to silence:
 #   * `localapi: [POST] /localapi/v0/debug` — containerboot's own 15s
 #     peerPoll watcher hitting the local LocalAPI debug action. Unix
-#     socket only, no network I/O, fires every 15s for the life of the
-#     container.
+#     socket only, no network I/O.
 #   * `magicsock: derp-NN does not know about peer [XX/YY], removing
 #     route` — disco probe spam against an offline peer's cached home
 #     DERP region; loops every ~5s until that peer reconnects.
-# awk is in busybox, doesn't need GNU-grep's --line-buffered, and we
-# call fflush() to keep balena's log shipper seeing lines promptly.
+#   * `[RATELIMIT] format("magicsock: derp-%d does not know about
+#     peer …")` — tailscaled's rate-limiter meta-line for the above.
+#
+# We route via a FIFO + background awk reader rather than the obvious
+# `exec containerboot | awk` pipeline so that containerboot remains
+# tini's direct child: a pipeline would replace this shell with awk,
+# breaking SIGTERM forwarding to containerboot and masking its exit
+# code. With the FIFO, containerboot is exec'd into the current
+# process (so its PID is tini's child) and writes to the FIFO; awk
+# reads, filters, and emits to the inherited container stdout. When
+# containerboot exits, the FIFO write side closes and awk reaches
+# EOF on its own; tini reaps both. awk is in busybox and we call
+# fflush() per line so balena's log shipper sees output promptly.
 
-exec /usr/local/bin/containerboot 2>&1 | awk '
+LOG_FIFO=/tmp/ts-log.fifo
+rm -f "$LOG_FIFO"
+mkfifo -m 0600 "$LOG_FIFO"
+
+awk '
 	/localapi: \[POST\] \/localapi\/v0\/debug/ { next }
 	/magicsock: derp-[0-9]+ does not know about peer/ { next }
 	/\[RATELIMIT\] format\("magicsock: derp-%d does not know about peer/ { next }
 	{ print; fflush() }
-'
+' < "$LOG_FIFO" &
+
+exec /usr/local/bin/containerboot > "$LOG_FIFO" 2>&1

--- a/tailscale/start.sh
+++ b/tailscale/start.sh
@@ -25,15 +25,17 @@ esac
 #                       login URL to the container logs; open it in your
 #                       SSO-enabled browser to authorize the device.
 
-if [ -z "${TS_AUTHKEY:-}" ]; then
+if [ -n "${TS_AUTHKEY:-}" ]; then
+	echo "TS_AUTHKEY is set, proceeding with non-interactive authentication."
+	echo " "
+elif [ -z "$(ls -A /var/lib/tailscale 2>/dev/null)" ]; then
+	# No auth key AND no persisted state — first-boot SSO flow.
 	echo "TS_AUTHKEY is not set – Tailscale will print an interactive login URL"
 	echo "to the container logs. Open it in your SSO-enabled browser to authorize"
 	echo "this device, or set TS_AUTHKEY to a pre-auth key / OAuth client secret."
-else
-	echo "TS_AUTHKEY is set, proceeding with non-interactive authentication."
+	echo " "
 fi
-
-echo " "
+# else: state already exists, tailscaled will resume silently — no banner.
 
 # balena-friendly defaults; only set when the user has not overridden.
 
@@ -53,9 +55,6 @@ mkdir -p /dev/net
 if [ ! -c /dev/net/tun ]; then
 	mknod /dev/net/tun c 10 200
 fi
-
-mount -o remount,rw /proc/sys 2>/dev/null || \
-	echo "remount /proc/sys rw failed; tailscaled will warn about src_valid_mark and connmark rp_filter workaround will be ineffective."
 
 # Optional: terminate Tailscale Serve (HTTPS on :443) in front of traefik. The
 # file ships unmodified — ${TS_CERT_DOMAIN} inside is a magic placeholder


### PR DESCRIPTION
## Summary

- New `tailscale` service, built on top of [`klutchell/balena-tailscale`](https://github.com/klutchell/balena-tailscale), pinned via Renovate (`tailscale/Dockerfile.template`).
- Opt-in via `ENABLED_SERVICES`: if the service name is absent, `start.sh` asks the Supervisor to stop the container, so non-adopters pay no runtime cost.
- Three auth flows configured through `TS_AUTHKEY`: pre-auth key, OAuth client, or interactive SSO URL (printed as a banner in container logs when `TS_AUTHKEY` is empty).
- Optional Tailscale Serve in front of traefik gated by `TAILSCALE_SERVE_TRAEFIK`; ships a `serve.json` with the `${TS_CERT_DOMAIN}` placeholder unmodified.
- Two-stage post-up `tailscale set` runner in `start.sh`: stage 1 applies `--update-check=$TS_UPDATE_CHECK` as soon as the LocalAPI accepts prefs; stage 2 waits for `BackendState=Running` and applies `TS_POST_UP_SET_ARGS` (re-applying `--update-check` defensively).
- Persists state to a new `tailscale-state` volume; runs `network_mode: host` so the device's tailnet IP automatically reaches every already-published port (traefik, dump1090-fa, fr24feed, planefinder, tar1090, dump978-fa, …).
- README documents the service, its auth flows, every `TS_*` env var the fork exposes, and the captive-portal ACL knob recommended for noisy logs.

## Files

- `tailscale/Dockerfile.template`
- `tailscale/start.sh`
- `tailscale/serve.json`
- `docker-compose.yml` (new service + `tailscale-state` volume)
- `README.md` (Part 15 entry + troubleshooting)

## Test plan

- [ ] Deploy with `ENABLED_SERVICES` unset → tailscale container stops itself, no other services affected.
- [ ] Deploy with `ENABLED_SERVICES=tailscale` and a `tskey-auth-…` value → device appears in the tailnet on first boot.
- [ ] Deploy with `ENABLED_SERVICES=tailscale` and empty `TS_AUTHKEY` → login URL banner appears in `balena logs --service tailscale`.
- [ ] From another tailnet device, browse `http://<device>.<tailnet>.ts.net/` and confirm traefik-served paths (skyaware, tar1090, fr24feed, …) work.
- [ ] Set `TAILSCALE_SERVE_TRAEFIK=true` and confirm `https://<device>.<tailnet>.ts.net/` serves traefik with an auto-issued cert.
- [ ] Reboot the device → tailscale rejoins from `tailscale-state` without re-auth.


Closes: https://github.com/ketilmo/balena-ads-b/issues/532
