### PR TITLE
fix(start.sh): tolerate supervisor curl failure on opt-out gate

### DIFF
--- a/adsb-exchange/start.sh
+++ b/adsb-exchange/start.sh
@@ -5,10 +5,6 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
-        # `set -e` and skip the sleep -- under sustained supervisor failure
-        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
-        # instead of idling cleanly.
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity

--- a/adsb-exchange/start.sh
+++ b/adsb-exchange/start.sh
@@ -5,7 +5,11 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
+        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
+        # `set -e` and skip the sleep -- under sustained supervisor failure
+        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
+        # instead of idling cleanly.
+        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity
 fi

--- a/airnav-radar/start.sh
+++ b/airnav-radar/start.sh
@@ -5,10 +5,6 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
-        # `set -e` and skip the sleep -- under sustained supervisor failure
-        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
-        # instead of idling cleanly.
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity

--- a/airnav-radar/start.sh
+++ b/airnav-radar/start.sh
@@ -5,7 +5,11 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
+        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
+        # `set -e` and skip the sleep -- under sustained supervisor failure
+        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
+        # instead of idling cleanly.
+        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity
 fi

--- a/dump1090-fa/start.sh
+++ b/dump1090-fa/start.sh
@@ -6,10 +6,6 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]] || [[ "$DUMP978_IDLE" = "true" ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
-        # `set -e` and skip the sleep -- under sustained supervisor failure
-        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
-        # instead of idling cleanly.
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity

--- a/dump1090-fa/start.sh
+++ b/dump1090-fa/start.sh
@@ -6,7 +6,11 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]] || [[ "$DUMP978_IDLE" = "true" ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
+        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
+        # `set -e` and skip the sleep -- under sustained supervisor failure
+        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
+        # instead of idling cleanly.
+        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity
 fi

--- a/dump978-fa/start.sh
+++ b/dump978-fa/start.sh
@@ -6,10 +6,6 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]] || [[ "$DUMP1090_IDLE" = "true" ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
-        # `set -e` and skip the sleep -- under sustained supervisor failure
-        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
-        # instead of idling cleanly.
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity
@@ -19,10 +15,6 @@ fi
 
 if ! [[ "$UAT_ENABLED" = "true" ]]; then
         echo "$BALENA_SERVICE_NAME is not enabled. Sending request to stop the service:"
-        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
-        # `set -e` and skip the sleep -- under sustained supervisor failure
-        # this UAT_ENABLED idle branch would otherwise restart every 24h
-        # instead of idling cleanly.
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity

--- a/dump978-fa/start.sh
+++ b/dump978-fa/start.sh
@@ -6,7 +6,11 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]] || [[ "$DUMP1090_IDLE" = "true" ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
+        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
+        # `set -e` and skip the sleep -- under sustained supervisor failure
+        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
+        # instead of idling cleanly.
+        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity
 fi
@@ -15,7 +19,11 @@ fi
 
 if ! [[ "$UAT_ENABLED" = "true" ]]; then
         echo "$BALENA_SERVICE_NAME is not enabled. Sending request to stop the service:"
-        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
+        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
+        # `set -e` and skip the sleep -- under sustained supervisor failure
+        # this UAT_ENABLED idle branch would otherwise restart every 24h
+        # instead of idling cleanly.
+        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity
 fi

--- a/fr24feed/start.sh
+++ b/fr24feed/start.sh
@@ -5,10 +5,6 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
-        # `set -e` and skip the sleep -- under sustained supervisor failure
-        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
-        # instead of idling cleanly.
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity

--- a/fr24feed/start.sh
+++ b/fr24feed/start.sh
@@ -5,7 +5,11 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
+        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
+        # `set -e` and skip the sleep -- under sustained supervisor failure
+        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
+        # instead of idling cleanly.
+        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity
 fi

--- a/ident/start.sh
+++ b/ident/start.sh
@@ -5,10 +5,6 @@ set -e
 
 if [[ ",$(echo -e "${ENABLED_SERVICES}" | tr -d '[:space:]')," != *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is not enabled. Sending request to stop the service:"
-        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
-        # `set -e` and skip the sleep — under sustained supervisor failure
-        # this ENABLED_SERVICES opt-out branch would otherwise restart every
-        # 24h instead of idling cleanly.
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity

--- a/ident/start.sh
+++ b/ident/start.sh
@@ -5,7 +5,11 @@ set -e
 
 if [[ ",$(echo -e "${ENABLED_SERVICES}" | tr -d '[:space:]')," != *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is not enabled. Sending request to stop the service:"
-        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
+        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
+        # `set -e` and skip the sleep — under sustained supervisor failure
+        # this ENABLED_SERVICES opt-out branch would otherwise restart every
+        # 24h instead of idling cleanly.
+        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity
 fi

--- a/kiosk/start.sh
+++ b/kiosk/start.sh
@@ -5,10 +5,6 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
-        # `set -e` and skip the sleep -- under sustained supervisor failure
-        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
-        # instead of idling cleanly.
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity

--- a/kiosk/start.sh
+++ b/kiosk/start.sh
@@ -5,7 +5,11 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
+        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
+        # `set -e` and skip the sleep -- under sustained supervisor failure
+        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
+        # instead of idling cleanly.
+        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity
 fi

--- a/mlat-client/start.sh
+++ b/mlat-client/start.sh
@@ -5,10 +5,6 @@ set -e
 
 if [[ ",$(echo -e "${ENABLED_SERVICES}" | tr -d '[:space:]')," != *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is not enabled. Sending request to stop the service:"
-        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
-        # `set -e` and skip the sleep — under sustained supervisor failure
-        # this ENABLED_SERVICES opt-out branch would otherwise restart every
-        # 24h instead of idling cleanly.
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity

--- a/mlat-client/start.sh
+++ b/mlat-client/start.sh
@@ -5,7 +5,11 @@ set -e
 
 if [[ ",$(echo -e "${ENABLED_SERVICES}" | tr -d '[:space:]')," != *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is not enabled. Sending request to stop the service:"
-        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
+        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
+        # `set -e` and skip the sleep — under sustained supervisor failure
+        # this ENABLED_SERVICES opt-out branch would otherwise restart every
+        # 24h instead of idling cleanly.
+        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity
 fi

--- a/opensky-network/start.sh
+++ b/opensky-network/start.sh
@@ -5,10 +5,6 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
-        # `set -e` and skip the sleep -- under sustained supervisor failure
-        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
-        # instead of idling cleanly.
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity

--- a/opensky-network/start.sh
+++ b/opensky-network/start.sh
@@ -5,7 +5,11 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
+        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
+        # `set -e` and skip the sleep -- under sustained supervisor failure
+        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
+        # instead of idling cleanly.
+        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity
 fi

--- a/piaware/start.sh
+++ b/piaware/start.sh
@@ -5,10 +5,6 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
-        # `set -e` and skip the sleep -- under sustained supervisor failure
-        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
-        # instead of idling cleanly.
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity

--- a/piaware/start.sh
+++ b/piaware/start.sh
@@ -5,7 +5,11 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
+        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
+        # `set -e` and skip the sleep -- under sustained supervisor failure
+        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
+        # instead of idling cleanly.
+        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity
 fi

--- a/planefinder/start.sh
+++ b/planefinder/start.sh
@@ -5,10 +5,6 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
-        # `set -e` and skip the sleep -- under sustained supervisor failure
-        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
-        # instead of idling cleanly.
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity

--- a/planefinder/start.sh
+++ b/planefinder/start.sh
@@ -5,7 +5,11 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
+        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
+        # `set -e` and skip the sleep -- under sustained supervisor failure
+        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
+        # instead of idling cleanly.
+        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity
 fi

--- a/planewatch/start.sh
+++ b/planewatch/start.sh
@@ -5,10 +5,6 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
-        # `set -e` and skip the sleep -- under sustained supervisor failure
-        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
-        # instead of idling cleanly.
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity

--- a/planewatch/start.sh
+++ b/planewatch/start.sh
@@ -5,7 +5,11 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
+        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
+        # `set -e` and skip the sleep -- under sustained supervisor failure
+        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
+        # instead of idling cleanly.
+        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity
 fi

--- a/tailscale/start.sh
+++ b/tailscale/start.sh
@@ -8,7 +8,11 @@ case ",$(echo "${ENABLED_SERVICES:-}" | tr -d '[:space:]')," in
 		;;
 	*)
 		echo "$BALENA_SERVICE_NAME is not enabled. Sending request to stop the service:"
-		curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'"$BALENA_SERVICE_NAME"'"}'
+		# `|| true` so a curl that exhausts its 24h retry budget doesn't trip
+		# `set -e` and skip the sleep — under sustained supervisor failure
+		# this ENABLED_SERVICES opt-out branch would otherwise restart every
+		# 24h instead of idling cleanly.
+		curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'"$BALENA_SERVICE_NAME"'"}' || true
 		echo " "
 		sleep infinity
 		;;

--- a/tailscale/start.sh
+++ b/tailscale/start.sh
@@ -8,10 +8,6 @@ case ",$(echo "${ENABLED_SERVICES:-}" | tr -d '[:space:]')," in
 		;;
 	*)
 		echo "$BALENA_SERVICE_NAME is not enabled. Sending request to stop the service:"
-		# `|| true` so a curl that exhausts its 24h retry budget doesn't trip
-		# `set -e` and skip the sleep — under sustained supervisor failure
-		# this ENABLED_SERVICES opt-out branch would otherwise restart every
-		# 24h instead of idling cleanly.
 		curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'"$BALENA_SERVICE_NAME"'"}' || true
 		echo " "
 		sleep infinity

--- a/traefik/start.sh
+++ b/traefik/start.sh
@@ -5,10 +5,6 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
-        # `set -e` and skip the sleep -- under sustained supervisor failure
-        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
-        # instead of idling cleanly.
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity

--- a/traefik/start.sh
+++ b/traefik/start.sh
@@ -5,7 +5,11 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
+        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
+        # `set -e` and skip the sleep -- under sustained supervisor failure
+        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
+        # instead of idling cleanly.
+        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity
 fi

--- a/wingbits/start.sh
+++ b/wingbits/start.sh
@@ -5,10 +5,6 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
-        # `set -e` and skip the sleep -- under sustained supervisor failure
-        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
-        # instead of idling cleanly.
         curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity

--- a/wingbits/start.sh
+++ b/wingbits/start.sh
@@ -5,7 +5,11 @@ set -e
 
 if [[ ",$(echo -e "${DISABLED_SERVICES}" | tr -d '[:space:]')," = *",$BALENA_SERVICE_NAME,"* ]]; then
         echo "$BALENA_SERVICE_NAME is manually disabled. Sending request to stop the service:"
-        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}'
+        # `|| true` so a curl that exhausts its 24h retry budget doesn't trip
+        # `set -e` and skip the sleep -- under sustained supervisor failure
+        # this DISABLED_SERVICES idle branch would otherwise restart every 24h
+        # instead of idling cleanly.
+        curl --fail --retry 86400 --retry-delay 1 --retry-all-errors --header "Content-Type:application/json" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/stop-service?apikey=$BALENA_SUPERVISOR_API_KEY" -d '{"serviceName": "'$BALENA_SERVICE_NAME'"}' || true
         echo " "
         sleep infinity
 fi


### PR DESCRIPTION
## Problem

Every service whose `start.sh` has an idle branch shaped like:

```sh
set -e
…
    # gate fires when the service should idle
    curl --fail --retry 86400 --retry-delay 1 --retry-all-errors … stop-service …
    sleep infinity
```

…has a latent failure mode: if the supervisor is unreachable for the full 24-hour retry budget, `curl` exits non-zero, `set -e` kills the script before `sleep infinity` is reached, and balena restarts the container — repeating roughly once every 24 hours instead of letting the service idle.

Not a tight crash-loop, but a real correctness gap and a quick fix.

## Fix

Append `|| true` to the `curl` so an exhausted retry budget falls through to `sleep infinity`. Behavior in the happy path is unchanged: when the supervisor is reachable, it stops the container before the script reaches the sleep anyway.

## Scope

Every service in the repo that uses this pattern. Three gating mechanisms, all affected:

- **`ENABLED_SERVICES` (opt-in)**: `ident`, `mlat-client`, `tailscale`
- **`DISABLED_SERVICES` (opt-out)**: `adsb-exchange`, `airnav-radar`, `dump1090-fa`, `dump978-fa`, `fr24feed`, `kiosk`, `opensky-network`, `piaware`, `planefinder`, `planewatch`, `traefik`, `wingbits`
- **`UAT_ENABLED` (per-service)**: `dump978-fa` has a second gate with the same pattern, also fixed

15 sites total across 14 files. (`dump978-fa` is patched in two places.)

`wifi-connect/start.sh` matches the `curl` pattern grep but does not run under `set -e`, so its `sleep infinity` is reached regardless of curl's exit status — no change needed.

## Context

Spotted by @Teko012 during review of #541. The two new services introduced in that PR (`otel-collector` and `dump1090-exporter`) carry the same fix inside the PR itself; this PR closes the loop on all the services that already use this pattern in master. `traefik` and `wingbits` were added in a follow-up commit after Copilot flagged them.

## Risk

Tiny. The added clause only affects the idle branch, which is by definition meant to sleep forever. No live-validation possible without manufacturing a 24-hour supervisor outage.