### PR TITLE
Moves configs to repo variables

### DIFF
--- a/.github/workflows/deploy-to-balena.yml
+++ b/.github/workflows/deploy-to-balena.yml
@@ -6,15 +6,12 @@ on:
     branches:
       - master
 
-env:
-  BALENA_APP: ketil/balena-ads-b
-
 permissions:
   contents: read
 
 jobs:
   build:
-    name: "Deploy-to-Balena"
+    name: "Deploy to Balena"
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout repository
@@ -31,6 +28,6 @@ jobs:
       - name: Deploy to Balena
         uses: balena-io/deploy-to-balena-action@578f912fe5172b3147c850fc3f1327b006598b68 # v2.2.12
         with:
-          balena_token: ${{ secrets.BALENA_API_KEY }}
-          fleet: ${{ env.BALENA_APP }}
+          balena_token: ${{ secrets.BALENA_TOKEN }}
+          fleet: ${{ vars.FLEET }}
           multi_dockerignore: true


### PR DESCRIPTION
This removes hard coded personal variables in the GitHub workflow and reads them from the repository's secrets and variables instead.
Note that the names are changed to match the name in the Balena workflow.