### PR TITLE
fix(wingbits): make Renovate update all digest variants together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,11 +22,10 @@
       "managerFilePatterns": [
         "/(^|/)wingbits/Dockerfile\\.template$/"
       ],
-      "matchStringsStrategy": "combination",
       "matchStrings": [
-        "ENV WINGBITS_COMMIT_ID=(?<currentValue>.*?)\\n",
-        "ENV WINGBITS_DATE=(?<currentDigest>.*?)\\n"
+        "ENV WINGBITS_COMMIT_ID=(?<currentValue>.*?)\\nENV WINGBITS_DATE=(?<currentDigest>.*?)\\n"
       ],
+      "autoReplaceStringTemplate": "ENV WINGBITS_COMMIT_ID={{{newValue}}}\nENV WINGBITS_DATE={{{newDigest}}}\n",
       "depNameTemplate": "wingbits-meta",
       "datasourceTemplate": "custom.wingbits-meta"
     },
@@ -35,11 +34,10 @@
       "managerFilePatterns": [
         "/(^|/)wingbits/Dockerfile\\.template$/"
       ],
-      "matchStringsStrategy": "combination",
       "matchStrings": [
-        "ENV WINGBITS_COMMIT_ID=(?<currentValue>.*?)\\n",
-        "ENV WINGBITS_SHA256_AMD64=(?<currentDigest>.*?)\\n"
+        "# wingbits-rev (?<currentValue>.*?)\\nENV WINGBITS_SHA256_AMD64=(?<currentDigest>.*?)\\n"
       ],
+      "autoReplaceStringTemplate": "# wingbits-rev {{{newValue}}}\nENV WINGBITS_SHA256_AMD64={{{newDigest}}}\n",
       "depNameTemplate": "wingbits-binary-amd64",
       "packageNameTemplate": "amd64",
       "datasourceTemplate": "custom.wingbits-binary"
@@ -49,11 +47,10 @@
       "managerFilePatterns": [
         "/(^|/)wingbits/Dockerfile\\.template$/"
       ],
-      "matchStringsStrategy": "combination",
       "matchStrings": [
-        "ENV WINGBITS_COMMIT_ID=(?<currentValue>.*?)\\n",
-        "ENV WINGBITS_SHA256_ARM64=(?<currentDigest>.*?)\\n"
+        "# wingbits-rev (?<currentValue>.*?)\\nENV WINGBITS_SHA256_ARM64=(?<currentDigest>.*?)\\n"
       ],
+      "autoReplaceStringTemplate": "# wingbits-rev {{{newValue}}}\nENV WINGBITS_SHA256_ARM64={{{newDigest}}}\n",
       "depNameTemplate": "wingbits-binary-arm64",
       "packageNameTemplate": "arm64",
       "datasourceTemplate": "custom.wingbits-binary"
@@ -63,11 +60,10 @@
       "managerFilePatterns": [
         "/(^|/)wingbits/Dockerfile\\.template$/"
       ],
-      "matchStringsStrategy": "combination",
       "matchStrings": [
-        "ENV WINGBITS_COMMIT_ID=(?<currentValue>.*?)\\n",
-        "ENV WINGBITS_SHA256_ARM=(?<currentDigest>.*?)\\n"
+        "# wingbits-rev (?<currentValue>.*?)\\nENV WINGBITS_SHA256_ARM=(?<currentDigest>.*?)\\n"
       ],
+      "autoReplaceStringTemplate": "# wingbits-rev {{{newValue}}}\nENV WINGBITS_SHA256_ARM={{{newDigest}}}\n",
       "depNameTemplate": "wingbits-binary-arm",
       "packageNameTemplate": "arm",
       "datasourceTemplate": "custom.wingbits-binary"

--- a/wingbits/Dockerfile.template
+++ b/wingbits/Dockerfile.template
@@ -12,17 +12,22 @@ ENV RECEIVER_PORT=30005
 # tracked by the wingbits-version custom manager in renovate.json.
 ENV WINGBITS_CONFIG_VERSION=0.2.1
 # WINGBITS_COMMIT_ID, WINGBITS_DATE and the per-arch SHA256 hashes
-# below are managed by Renovate. Each line is paired with
-# WINGBITS_COMMIT_ID via a combination-strategy regex manager keyed
-# off custom.wingbits-meta / custom.wingbits-binary, so the binary
-# URL and the verified checksum always refer to the same upstream
-# release. The SHA256 values are the base64 Sha256 strings from
-# install.wingbits.com/linux-<arch>.json — Renovate returns them
-# verbatim and the installer decodes them at build time.
+# below are managed by Renovate. Each value is paired with the
+# upstream release version on the same (or an adjacent "# wingbits-rev")
+# line so that Renovate's regex manager rewrites the version and the
+# digest together in a single replaceString — see the wingbits-meta /
+# wingbits-binary custom managers in renovate.json. The SHA256 values
+# are the base64 Sha256 strings from install.wingbits.com/linux-<arch>.json
+# — Renovate returns them verbatim and the installer decodes them at
+# build time. Keep the "# wingbits-rev" markers in sync with
+# WINGBITS_COMMIT_ID; Renovate does this automatically on update.
 ENV WINGBITS_COMMIT_ID=v1.12.0
 ENV WINGBITS_DATE=2026-05-12T13:27:03.248603202Z
+# wingbits-rev v1.12.0
 ENV WINGBITS_SHA256_AMD64=IJxqhEFAgnlMmnHv+kA3muQW9f98RVHTZrjvuAV8L3g=
+# wingbits-rev v1.12.0
 ENV WINGBITS_SHA256_ARM64=/rE+0E4nJMVvATDjccj5HxwGU1dmyW7d9wh/VerTFDI=
+# wingbits-rev v1.12.0
 ENV WINGBITS_SHA256_ARM=3Jv/zlPKVR8jShmR1RO1Rs9rgU5VqPArnztMQZ0cFwo=
 
 ARG PERM_INSTALL="curl ca-certificates gettext-base tini ncurses-dev zlib1g jq python3-pip python3-venv wget"


### PR DESCRIPTION
## Problem

Renovate only updates **one** of the wingbits digest variants on a version bump. This is visible right now in #557 (`v1.12.0 → v1.12.1`): it bumps `WINGBITS_COMMIT_ID` and one `SHA256`, but leaves `WINGBITS_DATE` and the other two arch digests stale.

### Root cause

The four wingbits custom managers use `matchStringsStrategy: "combination"` with `currentValue` (`WINGBITS_COMMIT_ID`) and `currentDigest` on **separate lines**. In combination mode Renovate sets the dependency's `replaceString` to the **last** matched line — the digest line — which contains no version string. On a version bump Renovate tries to substitute the new version into `replaceString`, can't find the old version there, and aborts:

```
"replaceString":"ENV WINGBITS_SHA256_AMD64=...\n","currentValue":"v1.12.0",
   "msg":"currentValue not found in string to replace"
→ "Error updating branch: update failure"
```

Depending on cache state this surfaces either as a hard `update failure` or as a partial update (one arch written, the rest dropped) — which is what #557 shows.

## Fix

Give each managed value a self-contained anchor so `replaceString` spans both the version and the digest, and replace via an explicit `autoReplaceStringTemplate`:

- `wingbits-meta` captures `COMMIT_ID` + `DATE` as one two-line match.
- Each `SHA256_*` line gets an adjacent `# wingbits-rev <version>` marker (the SHA lines carry no version of their own), captured as a two-line match.

Drops `combination` strategy entirely. Renovate keeps the `# wingbits-rev` markers in sync automatically.

## Verification

Validated with `renovate-config-validator --strict`, and confirmed end-to-end against a Mend-hosted dry run on a fork: the `wingbits version to latest` branch now updates `DATE` + all three `SHA256_*` digests (and `COMMIT_ID`) in a single commit, where the previous config aborted.

## Note on the digest warning

You may see `Could not determine new digest for update` for the wingbits custom datasources **while a wingbits update is pending**. This is pre-existing (present with the current config too) and benign: it's the `getDigest()` probe for the *current* pinned version, which `install.wingbits.com` no longer serves once a newer release exists. It self-clears as soon as the update PR is merged (current == latest). The version-bump digests are sourced from the release object, not this probe, so updates are unaffected. No config change is included for it, since suppressing it would mean abandoning `currentDigest` (and thus the digest writes).

Fixes the behaviour seen in #557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)