### PR TITLE
perf: trim per-container runtime memory for low-RAM devices (~94 MB)

### DIFF
--- a/autohupr/Dockerfile.template
+++ b/autohupr/Dockerfile.template
@@ -1,4 +1,4 @@
 # renovate: datasource=docker depName=ghcr.io/schubydoo/autohupr versioning=docker
-ARG AUTOHUPR_VERSION=0.5.9
+ARG AUTOHUPR_VERSION=0.5.10
 FROM ghcr.io/schubydoo/autohupr:${AUTOHUPR_VERSION}
 LABEL maintainer="https://github.com/ketilmo"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,16 +42,10 @@ services:
     restart: unless-stopped
     ports:
       - "80:80"
-    # Bound the Go runtime on low-RAM devices: GOMEMLIMIT is a soft cap that
-    # makes the GC reclaim before growing further; GOGC trims heap headroom
-    # (default 100 = grow to 2x live). Cuts RSS without the CPU cost of very
-    # aggressive GC. Starting values — tune per device.
+    # Bound the Go runtime to cut RSS; GOMAXPROCS=2 trims per-thread stacks (light proxy).
     environment:
       - GOGC=75
       - GOMEMLIMIT=64MiB
-      # traefik's RSS is dominated by non-heap (per-thread stacks + mmap), so
-      # GC tuning alone barely moved it. Cap the Go runtime's P/thread count —
-      # light proxy load tolerates 2 and it trims the thread-stack overhead.
       - GOMAXPROCS=2
     labels:
       io.balena.features.balena-socket: '1'
@@ -158,9 +152,7 @@ services:
     environment:
       - FLIGHTAWARE_FEEDER_ID=
       - DUMP978_ENABLED=false
-      # glibc malloc tuning: cap per-thread arenas (default 8xCPU) and trim
-      # freed memory back to the OS sooner. Lowers RSS for threaded Python on
-      # multi-core SBCs at negligible cost.
+      # glibc malloc tuning: fewer arenas + earlier trim -> lower RSS.
       - MALLOC_ARENA_MAX=2
       - MALLOC_TRIM_THRESHOLD_=131072
     labels:
@@ -325,13 +317,8 @@ services:
   autohupr:
     build: ./autohupr
     restart: unless-stopped
-    # No NODE_OPTIONS/UV_THREADPOOL_SIZE override here on purpose: the autohupr
-    # image bakes its own memory tuning (--max-semi-space-size=2,
-    # --max-old-space-size=48, --jitless, UV_THREADPOOL_SIZE=2), with the
-    # critical flags on the node CLI. A container env var fully OVERRIDES a
-    # Dockerfile ENV (no merge), so setting NODE_OPTIONS here would mask the
-    # image's --jitless. The tuned image is pinned via AUTOHUPR_VERSION in
-    # autohupr/Dockerfile.template.
+    # Don't set NODE_OPTIONS/UV_THREADPOOL_SIZE here — the image bakes its tuning on
+    # the node CLI and a compose env var would override (not merge) it.
     tmpfs:
       - /tmp/work
     labels:
@@ -374,7 +361,6 @@ services:
       - ALT=
       - MLAT_CLIENT_USER=
       - MLAT_SERVER=
-      # glibc malloc tuning (see piaware).
       - MALLOC_ARENA_MAX=2
       - MALLOC_TRIM_THRESHOLD_=131072
     labels:
@@ -390,7 +376,6 @@ services:
       - IDENT_DATA_DIR=/run/dump1090-fa
       - IDENT_UPSTREAM_TYPE=dump1090-fa
       - IDENT_BASE_PATH=/ident
-      # Bound the Go runtime (see frontend-proxy). Starting values — tune.
       - GOGC=75
       - GOMEMLIMIT=56MiB
     # expose: kept for docs, see dump1090-fa note
@@ -452,11 +437,7 @@ services:
     # pid: host lets the bundled node_exporter see all host processes.
     pid: host
     environment:
-      # Soft-cap the Go heap below the 256 MB mem_limit so the GC reclaims
-      # before hitting the hard cap. 200MiB is the measured sweet spot
-      # (~217 MB RSS @ normal CPU); 160MiB regressed — too far below otelcol's
-      # working set, so the GC thrashed (CPU up, RSS crept to ~247 MB). Also
-      # read by the bundled node_exporter, which stays far below it.
+      # Soft-cap the Go heap under the 256 MB mem_limit (200MiB measured; lower regressed).
       - GOGC=75
       - GOMEMLIMIT=200MiB
       - OTLP_ENDPOINT=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,17 @@ services:
     restart: unless-stopped
     ports:
       - "80:80"
+    # Bound the Go runtime on low-RAM devices: GOMEMLIMIT is a soft cap that
+    # makes the GC reclaim before growing further; GOGC trims heap headroom
+    # (default 100 = grow to 2x live). Cuts RSS without the CPU cost of very
+    # aggressive GC. Starting values — tune per device.
+    environment:
+      - GOGC=75
+      - GOMEMLIMIT=64MiB
+      # traefik's RSS is dominated by non-heap (per-thread stacks + mmap), so
+      # GC tuning alone barely moved it. Cap the Go runtime's P/thread count —
+      # light proxy load tolerates 2 and it trims the thread-stack overhead.
+      - GOMAXPROCS=2
     labels:
       io.balena.features.balena-socket: '1'
       io.balena.features.supervisor-api: '1'
@@ -147,6 +158,11 @@ services:
     environment:
       - FLIGHTAWARE_FEEDER_ID=
       - DUMP978_ENABLED=false
+      # glibc malloc tuning: cap per-thread arenas (default 8xCPU) and trim
+      # freed memory back to the OS sooner. Lowers RSS for threaded Python on
+      # multi-core SBCs at negligible cost.
+      - MALLOC_ARENA_MAX=2
+      - MALLOC_TRIM_THRESHOLD_=131072
     labels:
       io.balena.features.supervisor-api: '1'
   fr24feed:
@@ -309,6 +325,13 @@ services:
   autohupr:
     build: ./autohupr
     restart: unless-stopped
+    # No NODE_OPTIONS/UV_THREADPOOL_SIZE override here on purpose: the autohupr
+    # image bakes its own memory tuning (--max-semi-space-size=2,
+    # --max-old-space-size=48, --jitless, UV_THREADPOOL_SIZE=2), with the
+    # critical flags on the node CLI. A container env var fully OVERRIDES a
+    # Dockerfile ENV (no merge), so setting NODE_OPTIONS here would mask the
+    # image's --jitless. The tuned image is pinned via AUTOHUPR_VERSION in
+    # autohupr/Dockerfile.template.
     tmpfs:
       - /tmp/work
     labels:
@@ -351,6 +374,9 @@ services:
       - ALT=
       - MLAT_CLIENT_USER=
       - MLAT_SERVER=
+      # glibc malloc tuning (see piaware).
+      - MALLOC_ARENA_MAX=2
+      - MALLOC_TRIM_THRESHOLD_=131072
     labels:
       io.balena.features.supervisor-api: '1'
   ident:
@@ -364,6 +390,9 @@ services:
       - IDENT_DATA_DIR=/run/dump1090-fa
       - IDENT_UPSTREAM_TYPE=dump1090-fa
       - IDENT_BASE_PATH=/ident
+      # Bound the Go runtime (see frontend-proxy). Starting values — tune.
+      - GOGC=75
+      - GOMEMLIMIT=56MiB
     # expose: kept for docs, see dump1090-fa note
     # expose:
     #   - "8080"
@@ -423,6 +452,13 @@ services:
     # pid: host lets the bundled node_exporter see all host processes.
     pid: host
     environment:
+      # Soft-cap the Go heap below the 256 MB mem_limit so the GC reclaims
+      # before hitting the hard cap. 200MiB is the measured sweet spot
+      # (~217 MB RSS @ normal CPU); 160MiB regressed — too far below otelcol's
+      # working set, so the GC thrashed (CPU up, RSS crept to ~247 MB). Also
+      # read by the bundled node_exporter, which stays far below it.
+      - GOGC=75
+      - GOMEMLIMIT=200MiB
       - OTLP_ENDPOINT=
       - OTLP_AUTH_HEADER=
       - OTLP_HEADERS=

--- a/wingbits/Dockerfile.template
+++ b/wingbits/Dockerfile.template
@@ -30,7 +30,10 @@ ENV WINGBITS_SHA256_ARM64=aexUZcB4XskSwOvITRqApBh0UhSgQMVxZyQTwGK8yAA=
 # wingbits-rev v1.12.1
 ENV WINGBITS_SHA256_ARM=cA0GRqJ1q/miM7gm5xAL9CIL68044VDDqJctoDjTq+I=
 
-ARG PERM_INSTALL="curl ca-certificates gettext-base tini ncurses-dev zlib1g jq python3-pip python3-venv wget"
+# upx-ucl: used to decompress the UPX-packed wingbits client (see
+# wingbits_installer.sh / start.sh) so its code pages are demand-paged and
+# reclaimable rather than fully resident in anonymous RAM on low-RAM devices.
+ARG PERM_INSTALL="curl ca-certificates gettext-base tini ncurses-dev zlib1g jq python3-pip python3-venv wget upx-ucl"
 
 RUN printf '%s\n' \
 		'path-exclude /usr/share/doc/*' \

--- a/wingbits/start.sh
+++ b/wingbits/start.sh
@@ -110,10 +110,10 @@ if [ "$version" != "$local_version" ] || [ "$json_version" != "$local_json_versi
     rm -rf $WINGBITS_PATH/wingbits
     gunzip $WINGBITS_PATH/wingbits.gz
     chmod +x $WINGBITS_PATH/wingbits
-    # Decompress the UPX-packed client so its code pages are demand-paged and
-    # reclaimable instead of fully resident in RAM (see wingbits_installer.sh).
+    # Decompress UPX (see wingbits_installer.sh); best-effort so an upx
+    # failure doesn't crash-loop the container — the packed binary works.
     if grep -qa 'UPX!' "$WINGBITS_PATH/wingbits"; then
-        upx -d "$WINGBITS_PATH/wingbits"
+        upx -d "$WINGBITS_PATH/wingbits" || echo "wingbits: upx -d failed; using packed binary"
     fi
     echo "$version" > $WINGBITS_VERSION_PATH/version
     echo "$json_version" > $WINGBITS_VERSION_PATH/json-version

--- a/wingbits/start.sh
+++ b/wingbits/start.sh
@@ -108,8 +108,13 @@ if [ "$version" != "$local_version" ] || [ "$json_version" != "$local_json_versi
     rm -rf $WINGBITS_PATH/wingbits.gz
     curl -s -o $WINGBITS_PATH/wingbits.gz "https://install.wingbits.com/$json_version/$GOOS-$GOARCH.gz"
     rm -rf $WINGBITS_PATH/wingbits
-    gunzip $WINGBITS_PATH/wingbits.gz 
+    gunzip $WINGBITS_PATH/wingbits.gz
     chmod +x $WINGBITS_PATH/wingbits
+    # Decompress the UPX-packed client so its code pages are demand-paged and
+    # reclaimable instead of fully resident in RAM (see wingbits_installer.sh).
+    if grep -qa 'UPX!' "$WINGBITS_PATH/wingbits"; then
+        upx -d "$WINGBITS_PATH/wingbits"
+    fi
     echo "$version" > $WINGBITS_VERSION_PATH/version
     echo "$json_version" > $WINGBITS_VERSION_PATH/json-version
     echo "New Wingbits version installed: $version"

--- a/wingbits/wingbits_installer.sh
+++ b/wingbits/wingbits_installer.sh
@@ -47,14 +47,12 @@ function setup_wingbits_client() {
 
 	chmod +x $WINGBITS_PATH/wingbits
 
-	# The upstream client is UPX-packed, which forces the whole ~36 MB
-	# executable to be resident in anonymous RAM at startup (non-shareable,
-	# non-reclaimable). Decompress it AFTER the checksum check (the published
-	# SHA256 is for the packed binary) so its code pages become demand-paged
-	# and reclaimable — a meaningful RSS saving on low-RAM devices. Guarded by
-	# the UPX magic so it's a no-op if upstream ever ships an unpacked binary.
+	# The upstream client is UPX-packed (whole exe resident in anon RAM).
+	# Decompress AFTER the checksum check (the published SHA256 is for the
+	# packed binary) so its code pages become demand-paged/reclaimable.
+	# Best-effort: keep the working packed binary if upx is missing or fails.
 	if grep -qa 'UPX!' "$WINGBITS_PATH/wingbits"; then
-		upx -d "$WINGBITS_PATH/wingbits"
+		upx -d "$WINGBITS_PATH/wingbits" || echo "wingbits: upx -d failed; using packed binary"
 	fi
 
 	PATH=$WINGBITS_PATH:$PATH

--- a/wingbits/wingbits_installer.sh
+++ b/wingbits/wingbits_installer.sh
@@ -46,6 +46,17 @@ function setup_wingbits_client() {
 	echo "$expected_sha256_hex  $WINGBITS_PATH/wingbits" | sha256sum -c -
 
 	chmod +x $WINGBITS_PATH/wingbits
+
+	# The upstream client is UPX-packed, which forces the whole ~36 MB
+	# executable to be resident in anonymous RAM at startup (non-shareable,
+	# non-reclaimable). Decompress it AFTER the checksum check (the published
+	# SHA256 is for the packed binary) so its code pages become demand-paged
+	# and reclaimable — a meaningful RSS saving on low-RAM devices. Guarded by
+	# the UPX magic so it's a no-op if upstream ever ships an unpacked binary.
+	if grep -qa 'UPX!' "$WINGBITS_PATH/wingbits"; then
+		upx -d "$WINGBITS_PATH/wingbits"
+	fi
+
 	PATH=$WINGBITS_PATH:$PATH
 }
 


### PR DESCRIPTION
## What & why

Trims steady-state RSS across the stack so it keeps running comfortably on 1 GB
devices (Raspberry Pi 3), **without disabling any service** — service enable/disable
stays the user's choice. All changes are runtime tuning (env vars + one unpack step);
**no functional behaviour changes**.

The ADS-B core is already cheap (`dump1090-fa` ~18 MB); the footprint lives in the
surrounding Go/Node services running with default, greedy runtimes — only
`otel-collector` had any memory limit before this.

## Changes per service

| Service | Change | Before → After* |
|---|---|---|
| `ident` (Go) | `GOMEMLIMIT=56MiB`, `GOGC=75` | 69 → ~30 MB |
| `otel-collector` (Go) | `GOMEMLIMIT=200MiB`, `GOGC=75` | 235 → 215 MB |
| `frontend-proxy` / traefik (Go) | `GOMEMLIMIT=64MiB`, `GOGC=75`, `GOMAXPROCS=2` | ~99 → ~88 MB (threads 11→8) |
| `piaware`, `mlat-client` (Python/glibc) | `MALLOC_ARENA_MAX=2`, `MALLOC_TRIM_THRESHOLD_=131072` | small |
| `wingbits` | `upx -d` the UPX-packed client (adds `upx-ucl`) | 54 → 49 MB (+~34 MB now reclaimable) |
| `autohupr` | bump to `0.5.10` (image bakes `--jitless` + V8 size flags + fetch-shim); drop now-redundant `NODE_OPTIONS`/`UV_THREADPOOL_SIZE` overrides | 79 → 60 MB (−24%, threads 11→9) |

**~94 MB total** worker-RSS reduction — ~9% of a Pi 3's entire RAM.

<sub>*Measured live on a Pi 4 / 8 GB (aarch64). Ratios transfer to a Pi 3; absolute
`GOMEMLIMIT` values should be confirmed on real Pi 3 hardware.</sub>

## Rationale / things learned (so reviewers don't have to re-derive)

- **`GOMEMLIMIT` helps most for Go services with small live heaps** (`ident` −65%).
- **It has a floor — don't set below the working set.** `otel-collector` at `160MiB`
  *regressed* (GC thrash: CPU ~52%, RSS crept to ~247 MB). `200MiB` is the measured
  sweet spot (~215 MB at normal CPU).
- **traefik's RSS is mostly non-heap** (per-thread stacks); `GOMAXPROCS=2` was the
  effective lever, not GC tuning.
- **wingbits client is Go but UPX-packed** (~9.6 → ~36 MB), so the whole executable
  sits resident in anonymous RAM. Unpacking (guarded `upx -d`, **after** the existing
  SHA256 verify, in both the build installer and the runtime self-update path) makes
  its code demand-paged and reclaimable. Direct saving is modest on a roomy device;
  the bigger benefit is under real Pi 3 memory pressure (reclaimable file pages vs.
  anonymous zram-only pages). Cost: ~26 MB larger wingbits image (disk, not RAM).
- **autohupr `--jitless`:** disables WebAssembly, and Node's `fetch`/undici uses a WASM
  llhttp parser — so `fetch()` breaks under `--jitless`. The `0.5.10` image fixes this
  with a `node-fetch`→`node:https` shim; verified that real HUP/supervisor check-ins
  complete. A container env var fully overrides a Dockerfile `ENV`, so the old compose
  overrides are removed to avoid masking the image's node-CLI flags.

## How tested

Deployed to a live Pi 4 (`raspberrypi4-64`, balenaOS 7.4.0) and measured per-container
`VmRSS` from `/proc` before/after each change; verified no crash loops, normal CPU, and
that `autohupr` completes real update check-ins. Each `GOMEMLIMIT` value was tuned
empirically (see the otel regression above).

## Not in scope (possible follow-ups)

- `otel-collector`: add a `memory_limiter` processor + trim `node_exporter` collectors.
- `autohupr`: replace `balena-sdk` with direct `node:https` (further RAM + keeps jitless happy).
- `wingbits`: ideally upstream ships the client unpacked instead of us decompressing it.
- Confirm `GOMEMLIMIT` values on real Pi 3 hardware.

## Dependency

Requires `autohupr` **0.5.10** (`ghcr.io/schubydoo/autohupr:0.5.10`), already released.
